### PR TITLE
refactor: remove CSV as output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Denet is a streaming process monitoring tool that provides detailed metrics on r
 - **eBPF-based profiling on Linux: off-CPU time and syscall tracking (optional)**
 - Recursive child process tracking
 - Command-line interface with colorized output
-- Multiple output formats (JSON, JSONL, CSV)
+- Multiple output formats (JSON, JSONL)
 - In-memory sample collection for Python API
 - Analysis utilities for metrics aggregation, peak detection, and resource utilization
 - Process metadata preserved in output files (pid, command, executable path)
@@ -148,7 +148,6 @@ print(f"Max processes: {summary['max_processes']}")
 # Save samples to different formats
 monitor.save_samples("metrics.jsonl")          # Default JSONL
 monitor.save_samples("metrics.json", "json")   # JSON array format
-monitor.save_samples("metrics.csv", "csv")     # CSV format
 
 # JSONL files include a metadata line at the beginning with process info
 # {"pid": 1234, "cmd": ["python"], "executable": "/usr/bin/python", "t0_ms": 1625184000000}
@@ -434,11 +433,6 @@ print(f"Found {len(cpu_peaks)} CPU usage peaks above 50%")
 stats = denet.resource_utilization(metrics)
 print(f"Average CPU: {stats['avg_cpu']}%")
 print(f"Total I/O: {stats['total_io_bytes']} bytes")
-
-# Convert between formats
-csv_data = denet.convert_format(metrics, to_format="csv")
-with open("metrics.csv", "w") as f:
-    f.write(csv_data)
 
 # Save metrics with custom options
 denet.save_metrics(metrics, "data.jsonl", format="jsonl", include_metadata=True)

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,6 @@ pub enum OutputFormat {
     #[default]
     JsonLines,
     Json,
-    Csv,
 }
 
 impl std::str::FromStr for OutputFormat {
@@ -24,7 +23,6 @@ impl std::str::FromStr for OutputFormat {
         match s.to_lowercase().as_str() {
             "json" => Ok(OutputFormat::Json),
             "jsonl" | "jsonlines" => Ok(OutputFormat::JsonLines),
-            "csv" => Ok(OutputFormat::Csv),
             _ => Err(DenetError::InvalidConfiguration(format!(
                 "Unknown output format: {s}"
             ))),
@@ -37,7 +35,6 @@ impl std::fmt::Display for OutputFormat {
         match self {
             OutputFormat::Json => write!(f, "json"),
             OutputFormat::JsonLines => write!(f, "jsonl"),
-            OutputFormat::Csv => write!(f, "csv"),
         }
     }
 }
@@ -320,15 +317,12 @@ mod tests {
             OutputFormat::from_str("jsonlines").unwrap(),
             OutputFormat::JsonLines
         );
-        assert_eq!(OutputFormat::from_str("csv").unwrap(), OutputFormat::Csv);
-
         // Test case insensitivity
         assert_eq!(OutputFormat::from_str("JSON").unwrap(), OutputFormat::Json);
         assert_eq!(
             OutputFormat::from_str("JSONL").unwrap(),
             OutputFormat::JsonLines
         );
-        assert_eq!(OutputFormat::from_str("CSV").unwrap(), OutputFormat::Csv);
 
         // Test invalid format
         let result = OutputFormat::from_str("invalid");
@@ -339,7 +333,6 @@ mod tests {
     fn test_output_format_display() {
         assert_eq!(OutputFormat::Json.to_string(), "json");
         assert_eq!(OutputFormat::JsonLines.to_string(), "jsonl");
-        assert_eq!(OutputFormat::Csv.to_string(), "csv");
     }
 
     #[test]
@@ -500,10 +493,10 @@ mod tests {
 
     #[test]
     fn test_output_config_builder_format_str() {
-        let result = OutputConfigBuilder::default().format_str("csv");
+        let result = OutputConfigBuilder::default().format_str("jsonl");
         assert!(result.is_ok());
         let config = result.unwrap().build();
-        assert_eq!(config.format, OutputFormat::Csv);
+        assert_eq!(config.format, OutputFormat::JsonLines);
     }
 
     #[test]
@@ -548,7 +541,7 @@ mod tests {
             ..Default::default()
         };
         let output_config = OutputConfig {
-            format: OutputFormat::Csv,
+            format: OutputFormat::Json,
             ..Default::default()
         };
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -422,62 +422,6 @@ impl PyProcessMonitor {
                 file.write_all(json_array.as_bytes())
                     .map_err(map_io_error)?;
             }
-            OutputFormat::Csv => {
-                // Write CSV header
-                writeln!(file, "ts_ms,cpu_usage,mem_rss_kb,mem_vms_kb,disk_read_bytes,disk_write_bytes,sys_net_rx_bytes,sys_net_tx_bytes,thread_count,uptime_secs")
-                    .map_err(map_io_error)?;
-
-                // Write data rows
-                for metrics_json in &self.samples {
-                    // Parse each JSON string to extract values
-                    if let Ok(metrics) = serde_json::from_str::<serde_json::Value>(metrics_json) {
-                        // Extract values with fallbacks to 0
-                        let ts_ms = metrics.get("ts_ms").and_then(|v| v.as_u64()).unwrap_or(0);
-                        let cpu_usage = metrics
-                            .get("cpu_usage")
-                            .and_then(|v| v.as_f64())
-                            .unwrap_or(0.0);
-                        let mem_rss_kb = metrics
-                            .get("mem_rss_kb")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let mem_vms_kb = metrics
-                            .get("mem_vms_kb")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let disk_read_bytes = metrics
-                            .get("disk_read_bytes")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let disk_write_bytes = metrics
-                            .get("disk_write_bytes")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let sys_net_rx_bytes = metrics
-                            .get("sys_net_rx_bytes")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let sys_net_tx_bytes = metrics
-                            .get("sys_net_tx_bytes")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let thread_count = metrics
-                            .get("thread_count")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let uptime_secs = metrics
-                            .get("uptime_secs")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-
-                        writeln!(
-                            file,
-                            "{ts_ms},{cpu_usage},{mem_rss_kb},{mem_vms_kb},{disk_read_bytes},{disk_write_bytes},{sys_net_rx_bytes},{sys_net_tx_bytes},{thread_count},{uptime_secs}"
-                        )
-                        .map_err(map_io_error)?;
-                    }
-                }
-            }
             OutputFormat::JsonLines => {
                 // Default to jsonl (one JSON object per line)
                 // The samples are already JSON strings, so just write them

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -21,15 +21,12 @@ fn test_output_format_from_str() {
         OutputFormat::from_str("jsonlines").unwrap(),
         OutputFormat::JsonLines
     );
-    assert_eq!(OutputFormat::from_str("csv").unwrap(), OutputFormat::Csv);
-
     // Test case insensitivity
     assert_eq!(OutputFormat::from_str("JSON").unwrap(), OutputFormat::Json);
     assert_eq!(
         OutputFormat::from_str("JSONL").unwrap(),
         OutputFormat::JsonLines
     );
-    assert_eq!(OutputFormat::from_str("CSV").unwrap(), OutputFormat::Csv);
 
     // Test invalid format
     let result = OutputFormat::from_str("invalid");
@@ -46,7 +43,6 @@ fn test_output_format_from_str() {
 fn test_output_format_display() {
     assert_eq!(OutputFormat::Json.to_string(), "json");
     assert_eq!(OutputFormat::JsonLines.to_string(), "jsonl");
-    assert_eq!(OutputFormat::Csv.to_string(), "csv");
 }
 
 #[test]
@@ -185,13 +181,6 @@ fn test_output_config_builder() {
     assert!(!config.update_in_place);
     assert!(config.write_metadata);
 
-    // Test format_str method
-    let result = OutputConfigBuilder::default().format_str("csv");
-
-    assert!(result.is_ok());
-    let config = result.unwrap().build();
-    assert_eq!(config.format, OutputFormat::Csv);
-
     // Test format_str with invalid value
     let result = OutputConfigBuilder::default().format_str("invalid");
 
@@ -229,7 +218,7 @@ fn test_denet_config_builder() {
     };
 
     let output_config = OutputConfig {
-        format: OutputFormat::Csv,
+        format: OutputFormat::Json,
         quiet: true,
         ..OutputConfig::default()
     };

--- a/tests/metadata_tests.rs
+++ b/tests/metadata_tests.rs
@@ -106,15 +106,6 @@ fn test_output_config_with_metadata_various_formats() {
     assert_eq!(config.format, OutputFormat::Json);
     assert!(config.write_metadata);
 
-    // Test with CSV format
-    let config = OutputConfigBuilder::default()
-        .format(OutputFormat::Csv)
-        .write_metadata(true)
-        .build();
-
-    assert_eq!(config.format, OutputFormat::Csv);
-    assert!(config.write_metadata);
-
     // Test with JSONL format (default)
     let config = OutputConfigBuilder::default().write_metadata(true).build();
 

--- a/tests/python/test_execute_with_monitoring.py
+++ b/tests/python/test_execute_with_monitoring.py
@@ -129,7 +129,7 @@ class TestExecuteWithMonitoring:
         cmd = [sys.executable, "-c", "import time; time.sleep(0.2)"]
 
         # Test each format separately
-        formats = ["jsonl", "json", "csv"]
+        formats = ["jsonl", "json"]
         for fmt in formats:
             output_file = str(tmp_path / f"metrics.{fmt}")
 
@@ -138,24 +138,11 @@ class TestExecuteWithMonitoring:
             assert exit_code == 0
             assert os.path.exists(output_file)
 
-            # Basic content check based on format
             with open(output_file, "r") as f:
                 content = f.read()
                 assert len(content) > 0
-
-                if fmt == "csv":
-                    # CSV should have header with common fields
-                    assert "ts_ms" in content
-                    assert "cpu_usage" in content
-                    assert "," in content
-                elif fmt == "json":
-                    # For denet, json format might not be an array but JSON object format
-                    assert "{" in content
-                    assert "}" in content
-                elif fmt == "jsonl":
-                    # JSONL has one JSON object per line
-                    assert "{" in content
-                    assert "}" in content
+                assert "{" in content
+                assert "}" in content
 
     def test_without_children(self, temp_output_file):
         """Test execution without monitoring child processes."""

--- a/tests/python/test_integration.py
+++ b/tests/python/test_integration.py
@@ -93,7 +93,7 @@ class TestExecuteWithMonitoring:
 
     def test_output_format_integration(self, tmp_path):
         """Test different output formats work end-to-end."""
-        formats = ["jsonl", "json", "csv"]
+        formats = ["jsonl", "json"]
 
         for fmt in formats:
             output_file = tmp_path / f"test_output.{fmt}"

--- a/tests/python/test_legacy_compatibility.py
+++ b/tests/python/test_legacy_compatibility.py
@@ -370,7 +370,7 @@ class TestBackwardsCompatibilityAPI:
         monitor.sample_once()
 
         # Test save operations in different formats
-        formats = ["jsonl", "json", "csv"]
+        formats = ["jsonl", "json"]
         for fmt in formats:
             temp_file = tmp_path / f"test_output.{fmt}"
 

--- a/tests/python/test_monitor_api.py
+++ b/tests/python/test_monitor_api.py
@@ -212,28 +212,6 @@ class TestProcessMonitorFileOutput:
         assert isinstance(data, list)
         assert len(data) > 0
 
-    def test_save_samples_csv(self, tmp_path):
-        """Test saving samples in CSV format."""
-        monitor = denet.ProcessMonitor(
-            cmd=["sleep", "0.2"], base_interval_ms=50, max_interval_ms=1000, store_in_memory=True
-        )
-
-        # Take samples
-        for _ in range(3):
-            monitor.sample_once()
-            time.sleep(0.05)
-
-        temp_file = tmp_path / "test_samples.csv"
-
-        monitor.save_samples(str(temp_file), "csv")
-        assert temp_file.exists()
-
-        with open(temp_file, "r") as f:
-            lines = [line.strip() for line in f if line.strip()]
-
-        assert len(lines) > 0
-        # First line should be header
-        assert "ts_ms" in lines[0] or "cpu_usage" in lines[0]
 
 
 class TestProcessMonitorSummary:


### PR DESCRIPTION
CSV had an incomplete, hardcoded implementation that silently dropped fields like GPU metrics, and was never supported in the CLI write path. Post-hoc CSV conversion via analysis.py remains the supported path for CSV export.