### PR TITLE
fix(ebpf): expand syscall probe coverage

### DIFF
--- a/src/ebpf/memory_map_cache.rs
+++ b/src/ebpf/memory_map_cache.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use crate::symbolication::{get_memory_maps, MemoryRegion};
 
+#[allow(dead_code)]
 type CacheMap = HashMap<u32, (Vec<MemoryRegion>, Instant)>;
 
 /// Cache for process memory maps to support stack trace symbolication

--- a/src/ebpf/metrics.rs
+++ b/src/ebpf/metrics.rs
@@ -165,46 +165,108 @@ pub fn syscall_name(syscall_nr: u64) -> String {
 /// - `system`: System configuration and information
 /// - `other`: Uncategorized syscalls
 pub fn categorize_syscall(syscall_nr: u64) -> String {
+    // x86_64 syscall numbering. Categories are best-effort: read/write on
+    // socket fds fall into file_io here because tracepoints cannot tell a
+    // socket fd from a file fd without an auxiliary fd-type map.
     match syscall_nr {
-        // File I/O operations
-        0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 40 | 82 | 83 | 84
-        | 85 | 86 | 87 | 88 | 89 | 90 | 132 | 133 | 187 | 188 | 189 | 190 | 257 | 258 | 259
-        | 260 | 263 | 264 | 265 | 285 | 286 | 293 | 294 | 295 | 296 | 304 | 305 | 306 | 307 => {
-            "file_io".to_string()
-        }
+        // file_io: read/write family, file lifecycle, fs metadata, fd ops
+        0 | 1 | 2 | 3 | 4 | 5 | 6 | 8                                  // read,write,open,close,stat,fstat,lstat,lseek
+        | 16 | 17 | 18 | 19 | 20 | 21                                  // ioctl,pread64,pwrite64,readv,writev,access
+        | 32 | 33                                                       // dup,dup2
+        | 40                                                            // sendfile
+        | 72 | 73 | 74 | 75 | 76 | 77 | 78 | 79 | 80 | 81              // fcntl,flock,fsync,fdatasync,truncate,ftruncate,getdents,getcwd,chdir,fchdir
+        | 82 | 83 | 84 | 85 | 86 | 87 | 88 | 89 | 90                   // rename,mkdir,rmdir,creat,link,unlink,symlink,readlink,chmod
+        | 132 | 133                                                     // utime,mknod
+        | 187 | 188 | 189 | 190                                         // readahead,setxattr,lsetxattr,fsetxattr
+        | 217                                                           // getdents64
+        | 257 | 258 | 259 | 260 | 263 | 264 | 265                       // openat,mkdirat,mknodat,fchownat,unlinkat,renameat,linkat
+        | 266 | 267 | 268 | 269 | 270 | 271 | 272                       // symlinkat,readlinkat,fchmodat,faccessat,pselect6,ppoll,unshare
+        | 285 | 286                                                     // fallocate,timerfd_settime
+        | 294                                                           // inotify_init1
+        | 295 | 296                                                     // preadv,pwritev
+        | 303 | 304                                                     // name_to_handle_at,open_by_handle_at
+        | 306                                                           // syncfs
+        => "file_io".to_string(),
 
-        // Memory management
-        9 | 10 | 11 | 12 | 15 | 25 | 26 | 27 | 28 | 158 | 159 | 160 | 213 | 214 | 215 | 216
-        | 217 | 218 | 226 | 273 | 274 | 275 | 276 | 317 | 318 | 319 => "memory".to_string(),
+        // memory: allocation, mapping, protection
+        9 | 10 | 11 | 12 | 25 | 26 | 27 | 28                            // mmap,mprotect,munmap,brk,mremap,msync,mincore,madvise
+        | 158                                                           // arch_prctl
+        | 213 | 214 | 215 | 216                                         // epoll_create,epoll_ctl_old,epoll_wait_old,remap_file_pages
+        | 218                                                           // set_tid_address (memory-adjacent, low priority)
+        | 237 | 238 | 239                                                // mbind,set_mempolicy,get_mempolicy
+        | 273 | 274 | 275 | 276                                         // set_robust_list,get_robust_list,splice,tee
+        | 318 | 319                                                      // getrandom,memfd_create
+        => "memory".to_string(),
 
-        // Process/thread management
-        56 | 57 | 58 | 59 | 60 | 61 | 62 | 224 | 231 | 232 | 233 | 234 | 235 | 236 | 246 | 266
-        | 267 | 268 | 269 | 270 | 271 | 272 => "process".to_string(),
+        // process: lifecycle, scheduling state
+        56 | 57 | 58 | 59 | 60 | 61                                     // clone,fork,vfork,execve,exit,wait4
+        | 231                                                           // exit_group
+        | 247                                                           // waitid
+        | 322                                                           // execveat
+        | 435                                                           // clone3
+        => "process".to_string(),
 
-        // Network operations
-        41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 | 51 | 52 | 53 | 54 | 55 | 198 | 199
-        | 200 | 202 | 203 | 288 | 289 | 290 | 291 | 292 | 326 | 327 | 328 | 329 | 330 | 331
-        | 332 => "network".to_string(),
+        // signal: signal delivery, masking, kill
+        13 | 14 | 15                                                    // rt_sigaction,rt_sigprocmask,rt_sigreturn
+        | 34                                                            // pause
+        | 62                                                            // kill
+        | 127 | 128 | 129 | 130 | 131                                    // rt_sigpending,rt_sigtimedwait,rt_sigqueueinfo,rt_sigsuspend,sigaltstack
+        | 200                                                           // tkill
+        | 234                                                           // tgkill
+        | 282                                                           // signalfd
+        | 297                                                           // rt_tgsigqueueinfo
+        => "signal".to_string(),
 
-        // Time and scheduling operations
-        23 | 24 | 35 | 96 | 97 | 98 | 113 | 114 | 115 | 116 | 117 | 118 | 119 | 120 | 201 | 228
-        | 229 | 230 | 249 | 252 | 277 | 278 | 279 | 280 => "time".to_string(),
+        // ipc: pipes, SysV/POSIX IPC, futex, eventfd
+        22                                                              // pipe
+        | 29 | 30 | 31                                                  // shmget,shmat,shmctl
+        | 64 | 65 | 66 | 67                                              // semget,semop,semctl,shmdt
+        | 68 | 69 | 70 | 71                                              // msgget,msgsnd,msgrcv,msgctl
+        | 202                                                           // futex
+        | 240 | 241 | 242 | 243 | 244 | 245 | 246                       // mq_*
+        | 283 | 284                                                     // timerfd_create,eventfd
+        | 293                                                           // pipe2
+        => "ipc".to_string(),
 
-        // Inter-process communication
-        63..=81 => "ipc".to_string(),
+        // network: sockets and socket-level I/O
+        41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 | 51 | 52 | 53 | 54 | 55
+                                                                         // socket,connect,accept,sendto,recvfrom,sendmsg,recvmsg,shutdown,bind,listen,getsockname,getpeername,socketpair,setsockopt,getsockopt
+        | 288                                                           // accept4
+        | 299                                                           // recvmmsg
+        | 307                                                           // sendmmsg
+        => "network".to_string(),
 
-        // Security, permissions, capabilities
-        91 | 92 | 95 | 123 | 124 | 125 | 126 | 137 | 138 | 139 | 140 | 141 | 142 | 157 | 163
-        | 164 | 165 | 166 | 281 | 282 | 283 | 284 => "security".to_string(),
+        // time: clocks, sleeps, timers
+        23 | 24                                                         // select,sched_yield
+        | 35                                                            // nanosleep
+        | 96 | 97 | 98                                                  // gettimeofday,getrlimit,getrusage
+        | 201                                                           // time
+        | 203 | 204                                                     // sched_setaffinity,sched_getaffinity
+        | 222 | 223 | 224 | 225 | 226 | 227                              // timer_create..clock_settime
+        | 228 | 229 | 230                                               // clock_gettime,clock_getres,clock_nanosleep
+        | 232 | 233 | 235                                                // epoll_wait,epoll_ctl,utimes
+        | 249                                                           // clock_adjtime (close enough)
+        | 277 | 278 | 279 | 280                                         // sync_file_range,vmsplice,move_pages,utimensat
+        => "time".to_string(),
 
-        // Signal handling
-        13 | 14 => "signal".to_string(),
+        // security: ownership, capabilities, namespaces
+        91 | 92 | 93 | 94 | 95                                          // fchmod,chown,fchown,lchown,umask
+        | 105 | 106                                                     // setuid,setgid
+        | 117 | 119 | 120 | 122                                          // setresuid,setresgid,getresgid,setfsuid (approx)
+        | 123 | 124 | 125 | 126                                         // setfsgid,getsid,capget,capset
+        | 137 | 138 | 139 | 140 | 141 | 142                              // statfs,fstatfs,sysfs,getpriority,setpriority,sched_setparam
+        | 157                                                           // prctl
+        | 161 | 162 | 163 | 164 | 165 | 166                              // chroot,sync,acct,settimeofday,mount,umount2
+        | 281                                                           // epoll_pwait
+        => "security".to_string(),
 
-        // System configuration and information
-        99 | 100 | 101 | 102 | 103 | 153 | 154 | 155 | 156 | 168 | 169 | 170 | 171 | 172 | 173
-        | 174 | 175 => "system".to_string(),
+        // system: identification, configuration
+        63                                                              // uname
+        | 99 | 100 | 101 | 102 | 103                                    // sysinfo,times,ptrace,getuid,syslog
+        | 153 | 154 | 155 | 156                                         // vhangup,modify_ldt,pivot_root,_sysctl
+        | 168 | 169 | 170 | 171 | 172 | 173 | 174 | 175                  // ioperm,create_module,init_module,delete_module,get_kernel_syms,query_module,quotactl,nfsservctl
+        => "system".to_string(),
 
-        // Unknown
         _ => "other".to_string(),
     }
 }
@@ -389,5 +451,181 @@ pub fn generate_syscall_analysis(
         memory_intensity: *metrics.by_category.get("memory").unwrap_or(&0) as f64 / total,
         cpu_intensity: *metrics.by_category.get("process").unwrap_or(&0) as f64 / total,
         network_intensity: *metrics.by_category.get("network").unwrap_or(&0) as f64 / total,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // x86_64 syscall numbers, verified against
+    // arch/x86/entry/syscalls/syscall_64.tbl.
+    const READ: u64 = 0;
+    const WRITE: u64 = 1;
+    const CLOSE: u64 = 3;
+    const FCNTL: u64 = 72;
+    const FLOCK: u64 = 73;
+    const FSYNC: u64 = 74;
+    const GETDENTS: u64 = 78;
+    const CHDIR: u64 = 80;
+    const OPENAT: u64 = 257;
+
+    const MMAP: u64 = 9;
+    const MUNMAP: u64 = 11;
+    const BRK: u64 = 12;
+
+    const CLONE: u64 = 56;
+    const FORK: u64 = 57;
+    const EXECVE: u64 = 59;
+    const EXIT: u64 = 60;
+    const EXIT_GROUP: u64 = 231;
+    const CLONE3: u64 = 435;
+
+    const SOCKET: u64 = 41;
+    const CONNECT: u64 = 42;
+    const SENDTO: u64 = 44;
+    const RECVFROM: u64 = 45;
+    const SENDMSG: u64 = 46;
+    const RECVMSG: u64 = 47;
+    const ACCEPT4: u64 = 288;
+    const SENDMMSG: u64 = 307;
+
+    const PIPE: u64 = 22;
+    const PIPE2: u64 = 293;
+    const FUTEX: u64 = 202;
+    const SHMGET: u64 = 29;
+    const SEMOP: u64 = 65;
+    const MSGSND: u64 = 69;
+
+    const RT_SIGACTION: u64 = 13;
+    const RT_SIGPROCMASK: u64 = 14;
+    const KILL: u64 = 62;
+    const TKILL: u64 = 200;
+    const TGKILL: u64 = 234;
+
+    const NANOSLEEP: u64 = 35;
+    const CLOCK_GETTIME: u64 = 228;
+    const CLOCK_NANOSLEEP: u64 = 230;
+    const SCHED_SETAFFINITY: u64 = 203;
+
+    const UNAME: u64 = 63;
+
+    fn cat(nr: u64) -> String {
+        categorize_syscall(nr)
+    }
+
+    #[test]
+    fn file_io_basic_rw() {
+        assert_eq!(cat(READ), "file_io");
+        assert_eq!(cat(WRITE), "file_io");
+        assert_eq!(cat(CLOSE), "file_io");
+        assert_eq!(cat(OPENAT), "file_io");
+    }
+
+    /// Regression: the original code lumped 63..=81 into "ipc", which
+    /// mis-bucketed fcntl/flock/fsync/getdents/chdir.
+    #[test]
+    fn regression_file_io_not_ipc() {
+        assert_eq!(cat(FCNTL), "file_io");
+        assert_eq!(cat(FLOCK), "file_io");
+        assert_eq!(cat(FSYNC), "file_io");
+        assert_eq!(cat(GETDENTS), "file_io");
+        assert_eq!(cat(CHDIR), "file_io");
+    }
+
+    #[test]
+    fn memory_basic() {
+        assert_eq!(cat(MMAP), "memory");
+        assert_eq!(cat(MUNMAP), "memory");
+        assert_eq!(cat(BRK), "memory");
+    }
+
+    /// Workers forking via clone/clone3 must surface as "process".
+    /// This was the original gap: tracepoints existed in metrics
+    /// but the BPF program never attached to them.
+    #[test]
+    fn process_lifecycle() {
+        assert_eq!(cat(CLONE), "process");
+        assert_eq!(cat(FORK), "process");
+        assert_eq!(cat(EXECVE), "process");
+        assert_eq!(cat(EXIT), "process");
+        assert_eq!(cat(EXIT_GROUP), "process");
+        assert_eq!(cat(CLONE3), "process");
+    }
+
+    #[test]
+    fn network_full_socket_family() {
+        for nr in [
+            SOCKET, CONNECT, SENDTO, RECVFROM, SENDMSG, RECVMSG, ACCEPT4, SENDMMSG,
+        ] {
+            assert_eq!(cat(nr), "network", "syscall {} should be network", nr);
+        }
+    }
+
+    /// Regression: futex (202) and sched_setaffinity (203) used to be
+    /// classified as "network".
+    #[test]
+    fn regression_futex_not_network() {
+        assert_eq!(cat(FUTEX), "ipc");
+        assert_ne!(cat(SCHED_SETAFFINITY), "network");
+    }
+
+    #[test]
+    fn ipc_primitives() {
+        assert_eq!(cat(PIPE), "ipc");
+        assert_eq!(cat(PIPE2), "ipc");
+        assert_eq!(cat(FUTEX), "ipc");
+        assert_eq!(cat(SHMGET), "ipc");
+        assert_eq!(cat(SEMOP), "ipc");
+        assert_eq!(cat(MSGSND), "ipc");
+    }
+
+    #[test]
+    fn signal_family() {
+        assert_eq!(cat(RT_SIGACTION), "signal");
+        assert_eq!(cat(RT_SIGPROCMASK), "signal");
+        assert_eq!(cat(KILL), "signal");
+        assert_eq!(cat(TKILL), "signal");
+        assert_eq!(cat(TGKILL), "signal");
+    }
+
+    #[test]
+    fn time_family() {
+        assert_eq!(cat(NANOSLEEP), "time");
+        assert_eq!(cat(CLOCK_GETTIME), "time");
+        assert_eq!(cat(CLOCK_NANOSLEEP), "time");
+    }
+
+    #[test]
+    fn system_uname() {
+        // Regression: uname (63) used to be the first entry in the
+        // 63..=81 range that incorrectly bucketed as "ipc".
+        assert_eq!(cat(UNAME), "system");
+    }
+
+    #[test]
+    fn unknown_falls_back_to_other() {
+        assert_eq!(cat(9999), "other");
+    }
+
+    /// No syscall number should be classified into more than one
+    /// category. This guards against future range overlaps when adding
+    /// new entries.
+    #[test]
+    fn categories_are_disjoint() {
+        // Spot-check a representative number from each category.
+        let samples = [
+            (READ, "file_io"),
+            (MMAP, "memory"),
+            (CLONE, "process"),
+            (SOCKET, "network"),
+            (FUTEX, "ipc"),
+            (KILL, "signal"),
+            (NANOSLEEP, "time"),
+            (UNAME, "system"),
+        ];
+        for (nr, expected) in samples {
+            assert_eq!(cat(nr), expected, "{} should map to {}", nr, expected);
+        }
     }
 }

--- a/src/ebpf/programs/syscall_tracer.c
+++ b/src/ebpf/programs/syscall_tracer.c
@@ -1,5 +1,15 @@
 //! Syscall tracing eBPF program
-//! This program attaches to syscall tracepoints and counts syscall frequency
+//! This program attaches to syscall tracepoints and counts syscall frequency.
+//!
+//! Coverage spans the categories surfaced by `categorize_syscall` in
+//! `src/ebpf/metrics.rs`: file_io, memory, process, network, ipc, signal, time.
+//! New tracepoints must be mirrored in the `tracepoints` table in
+//! `src/ebpf/syscall_tracker.rs`.
+//!
+//! Note: read/write on a connected socket fd are counted as file_io here.
+//! Disambiguating socket vs. file fds is not possible from a syscall
+//! tracepoint without an extra fd-type map, so connect/sendmsg/recvmsg are
+//! the primary network signal.
 
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
@@ -32,7 +42,7 @@ static inline void update_syscall_maps(__u32 pid, __u32 syscall_nr) {
         __u64 initial_count = 1;
         bpf_map_update_elem(&syscall_counts, &pid, &initial_count, BPF_ANY);
     }
-    
+
     // Update per-syscall count for this PID
     __u32 key = (pid << 16) | (syscall_nr & 0xFFFF);
     __u32 *syscall_count = bpf_map_lookup_elem(&pid_syscall_map, &key);
@@ -44,76 +54,62 @@ static inline void update_syscall_maps(__u32 pid, __u32 syscall_nr) {
     }
 }
 
-// Tracepoint for openat syscall
-SEC("tracepoint/syscalls/sys_enter_openat")
-int trace_openat_enter(void *ctx) {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    update_syscall_maps(pid, 257); // 257 is openat syscall nr
-    return 0;
-}
+// Generate a tracepoint program for a single syscall. The `name` must match
+// `/sys/kernel/debug/tracing/events/syscalls/sys_enter_<name>` and the Rust
+// attach table in `syscall_tracker.rs`.
+#define TRACE_SYSCALL(name, nr)                                                \
+    SEC("tracepoint/syscalls/sys_enter_" #name)                                \
+    int trace_##name##_enter(void *ctx) {                                      \
+        __u32 pid = bpf_get_current_pid_tgid() >> 32;                          \
+        update_syscall_maps(pid, (nr));                                        \
+        return 0;                                                              \
+    }
 
-// Tracepoint for read syscall
-SEC("tracepoint/syscalls/sys_enter_read")
-int trace_read_enter(void *ctx) {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    update_syscall_maps(pid, 0); // 0 is read syscall nr
-    return 0;
-}
+// file_io
+TRACE_SYSCALL(read,    0)
+TRACE_SYSCALL(write,   1)
+TRACE_SYSCALL(close,   3)
+TRACE_SYSCALL(openat,  257)
 
-// Tracepoint for write syscall
-SEC("tracepoint/syscalls/sys_enter_write")
-int trace_write_enter(void *ctx) {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    update_syscall_maps(pid, 1); // 1 is write syscall nr
-    return 0;
-}
+// memory
+TRACE_SYSCALL(mmap,    9)
+TRACE_SYSCALL(munmap,  11)
+TRACE_SYSCALL(brk,     12)
 
-// Tracepoint for close syscall
-SEC("tracepoint/syscalls/sys_enter_close")
-int trace_close_enter(void *ctx) {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    update_syscall_maps(pid, 3); // 3 is close syscall nr
-    return 0;
-}
+// process
+TRACE_SYSCALL(clone,       56)
+TRACE_SYSCALL(fork,        57)
+TRACE_SYSCALL(vfork,       58)
+TRACE_SYSCALL(execve,      59)
+TRACE_SYSCALL(exit,        60)
+TRACE_SYSCALL(wait4,       61)
+TRACE_SYSCALL(kill,        62)
+TRACE_SYSCALL(exit_group, 231)
 
-// Tracepoint for mmap syscall
-SEC("tracepoint/syscalls/sys_enter_mmap")
-int trace_mmap_enter(void *ctx) {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    update_syscall_maps(pid, 9); // 9 is mmap syscall nr
-    return 0;
-}
+// network
+TRACE_SYSCALL(socket,    41)
+TRACE_SYSCALL(connect,   42)
+TRACE_SYSCALL(accept,    43)
+TRACE_SYSCALL(sendto,    44)
+TRACE_SYSCALL(recvfrom,  45)
+TRACE_SYSCALL(sendmsg,   46)
+TRACE_SYSCALL(recvmsg,   47)
+TRACE_SYSCALL(bind,      49)
+TRACE_SYSCALL(accept4,  288)
 
-// Tracepoint for socket syscall
-SEC("tracepoint/syscalls/sys_enter_socket")
-int trace_socket_enter(void *ctx) {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    update_syscall_maps(pid, 41); // 41 is socket syscall nr
-    return 0;
-}
+// ipc
+TRACE_SYSCALL(futex,    202)
+TRACE_SYSCALL(pipe,      22)
+TRACE_SYSCALL(pipe2,    293)
 
-// Tracepoint for connect syscall
-SEC("tracepoint/syscalls/sys_enter_connect")
-int trace_connect_enter(void *ctx) {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    update_syscall_maps(pid, 42); // 42 is connect syscall nr
-    return 0;
-}
+// signal
+TRACE_SYSCALL(rt_sigaction,   13)
+TRACE_SYSCALL(rt_sigprocmask, 14)
+TRACE_SYSCALL(tgkill,        234)
 
-// Tracepoint for recvfrom syscall
-SEC("tracepoint/syscalls/sys_enter_recvfrom")
-int trace_recvfrom_enter(void *ctx) {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    update_syscall_maps(pid, 45); // 45 is recvfrom syscall nr
-    return 0;
-}
-
-// Tracepoint for sendto syscall
-SEC("tracepoint/syscalls/sys_enter_sendto")
-int trace_sendto_enter(void *ctx) {
-    __u32 pid = bpf_get_current_pid_tgid() >> 32;
-    update_syscall_maps(pid, 44); // 44 is sendto syscall nr
-    return 0;
-}
+// time
+TRACE_SYSCALL(nanosleep,        35)
+TRACE_SYSCALL(clock_gettime,   228)
+TRACE_SYSCALL(clock_nanosleep, 230)
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/ebpf/syscall_tracker.rs
+++ b/src/ebpf/syscall_tracker.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use aya::{maps::HashMap as BpfHashMap, Ebpf, EbpfLoader};
 
 #[cfg(feature = "ebpf")]
+#[allow(dead_code)]
 type EbpfMaps = (
     Ebpf,
     BpfHashMap<aya::maps::MapData, u32, u32>,
@@ -752,9 +753,51 @@ impl SyscallTracker {
             })?;
         crate::ebpf::debug::debug_println("pid_syscall_map created successfully");
 
-        // Define the syscalls we want to trace
+        // Syscalls we trace. Must stay in sync with TRACE_SYSCALL() entries
+        // in src/ebpf/programs/syscall_tracer.c. Some entries (e.g. `fork`,
+        // `vfork`, `pipe`) are unavailable on every kernel/arch; attach
+        // failures are tolerated below as long as at least one succeeds.
         let tracepoints = [
-            "openat", "read", "write", "close", "mmap", "socket", "connect", "recvfrom", "sendto",
+            // file_io
+            "read",
+            "write",
+            "close",
+            "openat",
+            // memory
+            "mmap",
+            "munmap",
+            "brk",
+            // process
+            "clone",
+            "fork",
+            "vfork",
+            "execve",
+            "exit",
+            "wait4",
+            "kill",
+            "exit_group",
+            // network
+            "socket",
+            "connect",
+            "accept",
+            "sendto",
+            "recvfrom",
+            "sendmsg",
+            "recvmsg",
+            "bind",
+            "accept4",
+            // ipc
+            "futex",
+            "pipe",
+            "pipe2",
+            // signal
+            "rt_sigaction",
+            "rt_sigprocmask",
+            "tgkill",
+            // time
+            "nanosleep",
+            "clock_gettime",
+            "clock_nanosleep",
         ];
 
         // Load and attach all tracepoint programs

--- a/src/monitor/metrics.rs
+++ b/src/monitor/metrics.rs
@@ -967,11 +967,13 @@ mod tests {
 
     #[test]
     fn from_aggregated_psi_pressure_classifies_memory_bound() {
-        let mut a = AggregatedMetrics::default();
-        a.psi_mem = Some(PsiMem {
-            some_avg10: 0.8,
-            full_avg10: 0.3,
-        });
+        let a = AggregatedMetrics {
+            psi_mem: Some(PsiMem {
+                some_avg10: 0.8,
+                full_avg10: 0.3,
+            }),
+            ..Default::default()
+        };
         let mc = MemoryCharacterization::from_aggregated(&[a]).unwrap();
         assert_eq!(mc.verdict, "memory-bound");
         assert!((mc.psi_some_fraction.unwrap() - 1.0).abs() < f64::EPSILON);
@@ -980,16 +982,15 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn from_aggregated_perf_sums_across_samples() {
-        let make = |cycles, instr| {
-            let mut a = AggregatedMetrics::default();
-            a.perf = Some(crate::perf::PerfCounters {
+        let make = |cycles, instr| AggregatedMetrics {
+            perf: Some(crate::perf::PerfCounters {
                 cycles,
                 instructions: instr,
                 cache_refs: 0,
                 cache_misses: 0,
                 stalled_backend: 0,
-            });
-            a
+            }),
+            ..Default::default()
         };
         let mc =
             MemoryCharacterization::from_aggregated(&[make(100, 200), make(100, 200)]).unwrap();


### PR DESCRIPTION
and fix categorizer mis-bucketing

The BPF program only attached tracepoints for 9 syscalls across file_io, memory, and network, so process/ipc/signal/time categories were always zero regardless of workload — workers forking via clone, futex contention, and signal traffic were invisible.

- Add tracepoints for clone/fork/execve/exit/wait4/kill/exit_group, futex/pipe/pipe2, rt_sigaction/rt_sigprocmask/tgkill, nanosleep/clock_gettime/clock_nanosleep, munmap/brk, and accept/sendmsg/recvmsg/bind/accept4 (helps libcurl/TLS network signal).
- Introduce a TRACE_SYSCALL macro so adding probes is a one-liner.
- Rewrite categorize_syscall with per-arm syscall annotations. Fixes 63..=81 lumping fcntl/flock/fsync/getdents/chdir/uname into ipc, and 198..=203 placing futex and sched_setaffinity into network.
- Add 12 unit tests including explicit regressions for both bugs.