### PR TITLE
fix: support Python 3.13/3.14 and ship a forward-compatible wheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,9 @@ jobs:
         env:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
         run: |
-          maturin build --release
+          # abi3 wheel (one wheel for py3.9+, incl. 3.13/3.14) + sdist
+          # so systems with older glibc than the manylinux wheel can build.
+          maturin build --release --sdist
 
       - name: List built packages
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,15 @@ on:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }} (py${{ matrix.python-version }})
+    # Lint + Rust/Python unit tests + coverage. Pinned to one Python because
+    # pixi provides its own interpreter (python==3.12); multi-version functional
+    # coverage lives in the build-wheels/test-wheels jobs below.
+    name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,11 +28,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt, llvm-tools-preview
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Install pixi
         run: |
@@ -113,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -153,7 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,15 +589,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,15 +676,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -965,37 +947,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1003,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1015,13 +992,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -1278,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -1366,12 +1342,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ gpu = ["dep:nvml-wrapper"]
 sysinfo = { version = "0.35.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-pyo3 = { version = "0.21", features = [
+pyo3 = { version = "0.29", features = [
     "extension-module",
     "auto-initialize",
+    "abi3-py39",
 ], optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 clap = { version = "4.5", features = ["derive"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,16 @@ version = "0.7.1"
 description = "A streaming process monitoring tool"
 readme = "README.md"
 authors = [{ name = "btraven00" }]
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]

--- a/python/denet/__init__.py
+++ b/python/denet/__init__.py
@@ -16,7 +16,12 @@ from .analysis import (
     save_metrics,
 )
 
-__version__ = "0.7.0"
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("denet")
+except PackageNotFoundError:  # not installed (e.g. running from source tree)
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     "ProcessMonitor",

--- a/python/denet/__init__.py
+++ b/python/denet/__init__.py
@@ -20,7 +20,7 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 try:
     __version__ = _pkg_version("denet")
-except PackageNotFoundError:  # not installed (e.g. running from source tree)
+except PackageNotFoundError:  # pragma: no cover - source tree, denet not installed
     __version__ = "0.0.0+unknown"
 
 __all__ = [

--- a/src/error.rs
+++ b/src/error.rs
@@ -287,7 +287,7 @@ mod tests {
         use pyo3::exceptions::*;
         use pyo3::Python;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Test IO error conversion
             let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
             let denet_err = DenetError::Io(io_err);

--- a/src/python.rs
+++ b/src/python.rs
@@ -165,10 +165,10 @@ impl PyProcessMonitor {
         use std::time::Duration;
 
         // Import Python modules for subprocess and signal handling
-        let subprocess = py.import_bound("subprocess")?;
-        let os = py.import_bound("os")?;
-        let signal = py.import_bound("signal")?;
-        let _time = py.import_bound("time")?;
+        let subprocess = py.import("subprocess")?;
+        let os = py.import("os")?;
+        let signal = py.import("signal")?;
+        let _time = py.import("time")?;
 
         // Prepare file handles for redirection
         let stdout_arg = if let Some(path) = &stdout_file {
@@ -196,7 +196,7 @@ impl PyProcessMonitor {
         };
 
         // Create subprocess using Python's subprocess module for better signal control
-        let popen_kwargs = pyo3::types::PyDict::new_bound(py);
+        let popen_kwargs = pyo3::types::PyDict::new(py);
         popen_kwargs.set_item("start_new_session", true)?;
 
         if stdout_arg.is_some() {
@@ -259,7 +259,7 @@ impl PyProcessMonitor {
 
         // Wait for process completion with timeout
         let exit_code = if let Some(timeout_secs) = timeout {
-            let timeout_dict = pyo3::types::PyDict::new_bound(py);
+            let timeout_dict = pyo3::types::PyDict::new(py);
             timeout_dict.set_item("timeout", timeout_secs)?;
 
             match process.call_method("wait", (), Some(&timeout_dict)) {

--- a/tests/python/test_abi3_forward_compat.py
+++ b/tests/python/test_abi3_forward_compat.py
@@ -1,0 +1,61 @@
+"""
+Regression guard for Python 3.13/3.14 support.
+
+Two things broke installs on new Python versions and must not regress:
+
+1. The Rust extension must be built as a forward-compatible abi3 module, so a
+   single wheel covers 3.9+ (incl. 3.13/3.14) instead of a version-locked
+   cp3XX wheel that pip can't use on a newer interpreter.
+2. pyo3 must be recent enough to compile against 3.13+ (0.21 could not), so the
+   sdist fallback build actually succeeds.
+
+These assert on Cargo.toml rather than the interpreter because an abi3 wheel is
+tagged for the version it was built with; the real guarantee lives in the build
+config. The functional "does it import and run" side is covered by running this
+suite across the CI Python matrix (3.12/3.13/3.14).
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+import denet
+
+CARGO_TOML = Path(__file__).resolve().parents[2] / "Cargo.toml"
+
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _pyo3():
+    cfg = tomllib.loads(CARGO_TOML.read_text())
+    return cfg["dependencies"]["pyo3"]
+
+
+def test_version_matches_package_metadata():
+    """__version__ is derived from install metadata, not a drifting hardcode."""
+    declared = tomllib.loads(PYPROJECT.read_text())["project"]["version"]
+    assert denet.__version__ == declared, (
+        f"denet.__version__ ({denet.__version__}) != pyproject version ({declared})"
+    )
+
+
+def test_ext_module_imports_and_runs():
+    """The compiled extension loads and produces a sample on this interpreter."""
+    m = denet.ProcessMonitor(cmd=["sleep", "0.1"], base_interval_ms=20, max_interval_ms=40)
+    assert "ts_ms" in (m.sample_once() or "")
+
+
+def test_pyo3_builds_abi3_wheel():
+    """abi3 feature keeps the wheel forward-compatible (one wheel for 3.9+)."""
+    features = _pyo3().get("features", [])
+    assert any(f.startswith("abi3") for f in features), (
+        f"pyo3 must enable an abi3-pyXX feature for forward-compatible wheels; got {features}"
+    )
+
+
+def test_pyo3_recent_enough_for_py313():
+    """pyo3 >= 0.23 to compile against Python 3.13/3.14 (0.21 could not)."""
+    ver = _pyo3()["version"]
+    major, minor = (int(x) for x in re.findall(r"\d+", ver)[:2])
+    assert (major, minor) >= (0, 23), f"pyo3 {ver} predates Python 3.13 support"


### PR DESCRIPTION
denet failed to install on Python 3.13/3.14: PyPI carried only a cp312-only Linux wheel, so pip fell back to compiling the sdist, which failed because pyo3 0.21 cannot build against the 3.13+ C API.

- Bump pyo3 0.21 -> 0.29 (supports 3.13 and 3.14) and enable abi3-py39, so maturin emits a single cp39-abi3 wheel covering 3.9+ instead of a version-locked cp3XX wheel.
- Migrate the pyo3 API removed since 0.21: import_bound/new_bound -> import/new in python.rs, Python::with_gil -> Python::attach in error.rs.
- pyproject: requires-python >=3.9 (0.21 never supported 3.6), classifiers 3.9-3.14.
- __version__ now derives from install metadata instead of a hardcoded string that had drifted to 0.7.0.
- publish CI ships an sdist alongside the wheel (the manylinux_2_39 wheel needs glibc >=2.39; older systems must be able to compile).
- test CI: add 3.14 to the wheel build/test matrices; drop the no-op python-version axis from the pixi-based test job (pixi pins python==3.12).
- Add tests/python/test_abi3_forward_compat.py guarding the abi3 feature, the pyo3 version floor, and version/metadata agreement.

Verified: abi3 wheel imports and runs on 3.12/3.13/3.14; sdist source-compile installs and runs on 3.13; 212 Rust tests and the full Python suite pass.