### PR TITLE
ci: add Python 3.15 (beta) to wheel matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14", "3.15"]
 
     steps:
       - uses: actions/checkout@v4
@@ -124,6 +124,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |
@@ -150,7 +151,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14", "3.15"]
 
     steps:
       - uses: actions/checkout@v4
@@ -159,6 +160,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Download wheels
         uses: actions/download-artifact@v4


### PR DESCRIPTION
3.15.0b3 is [out](https://www.python.org/downloads/release/python-3150b3/). Adds `"3.15"` to the `build-wheels` and `test-wheels` matrices with `allow-prereleases: true` so `setup-python` will fetch the beta.

The abi3 wheel shipped in #32 is already forward-compatible (one `cp39-abi3` binary covers 3.9+), so no runtime change is needed — this just exercises build + install on 3.15 to catch any pyo3 / stable-ABI breakage early.

Expected: green on 3.15 if the runners have a 3.15 build available. If setup-python can't resolve a 3.15 beta on a runner yet, that job will fail to provision and we hold the merge until it can.