### PR TITLE
feat(ebpf): per-process network byte accounting

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -109,7 +109,12 @@ fn compile_ebpf_programs() {
         .unwrap_or(false);
 
     // List of eBPF programs to compile
-    let ebpf_programs = vec!["syscall_tracer.c", "simple_test.c", "offcpu_profiler.c"];
+    let ebpf_programs = vec![
+        "syscall_tracer.c",
+        "simple_test.c",
+        "offcpu_profiler.c",
+        "net_monitor.c",
+    ];
 
     for program in ebpf_programs {
         let src_path = PathBuf::from(ebpf_src_dir).join(program);

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -127,7 +127,7 @@ Includes all fields from Individual Process Metrics plus:
 
 - **Default**: Shows delta I/O since monitoring started
 - **`--since-process-start`**: Shows cumulative I/O since process start
-- **Network I/O**: System-wide approximation (not per-process)
+- **Network I/O**: `sys_net_*` fields are a system-wide approximation (not per-process). With the `ebpf` feature and `--enable-ebpf`, per-process bytes appear under `ebpf.network` (see docs/ebpf.md).
 
 ## Output Options
 

--- a/docs/ebpf.md
+++ b/docs/ebpf.md
@@ -255,6 +255,56 @@ When eBPF profiling is enabled, JSON output will include additional fields:
 
 The `top_syscalls` field shows the most frequently called syscalls with their actual counts, and the `by_category` field shows how these syscalls are distributed across functional categories. The intensity fields are fractions of total tracked syscalls (uncategorized syscalls are excluded, so they do not sum to 1.0).
 
+## Per-Process Network Bytes
+
+With eBPF enabled, denet reports network bytes attributed to the monitored
+process tree — unlike the `sys_net_rx_bytes`/`sys_net_tx_bytes` fields, which
+remain a system-wide approximation from `/proc/net/dev` and are kept as the
+fallback when eBPF is unavailable.
+
+**How it works:** kprobes on the socket-layer send/receive paths
+(`tcp_sendmsg`/`tcp_recvmsg`, `udp_sendmsg`/`udp_recvmsg`) run in process
+context, so every byte is attributed by the kernel to the calling process. A
+BPF-side PID filter, synced with the process tree each sample, restricts
+accounting to the monitored tree.
+
+**Semantics:**
+
+- Cumulative since monitoring started, including bytes from children that
+  have already exited (totals never decrease).
+- RX counts bytes actually returned to userspace; TX counts bytes requested
+  at the socket layer (a failed send may overcount slightly).
+- Socket-layer application bytes: no TCP/IP headers, no retransmissions.
+- Covers TCP over IPv4 and IPv6, and UDP over IPv4. UDP over IPv6 uses
+  separate kernel entry points (`udpv6_sendmsg`) and is not yet counted.
+- Children that transfer bytes between fork and the next sample are picked
+  up at the next PID-filter sync (same window as syscall tracking).
+
+**JSON output** (inside the aggregated metrics' `ebpf` object):
+
+```json
+"network": { "rx_bytes": 10019992, "tx_bytes": 747 }
+```
+
+If eBPF could not attach (missing capabilities), the object carries an
+`error` string instead of silently reporting zeros as real data.
+
+**Required capabilities** are the same as the rest of the eBPF features
+(`cap_bpf,cap_perfmon,cap_dac_read_search` — see above). To verify the whole
+capability matrix, including graceful degradation without caps and real data
+with caps-but-no-root:
+
+```bash
+./scripts/test_ebpf_caps.sh            # Phases A (no caps) + B (setcap)
+./scripts/test_ebpf_caps.sh --with-root
+```
+
+The privileged integration tests can also be run directly:
+
+```bash
+sudo -E cargo test --features ebpf --test ebpf_net_monitor_tests -- --ignored
+```
+
 ## Implementation Details
 
 The eBPF implementation works by:

--- a/scripts/test_ebpf_caps.sh
+++ b/scripts/test_ebpf_caps.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Exercise the eBPF capability matrix for the net monitor:
+#
+#   Phase A  no caps, no root   → must degrade gracefully (error in metrics)
+#   Phase B  setcap, no root    → must produce real data (the case that has
+#                                 bitten us: caps instead of root)
+#   Phase C  root (--with-root) → optional sanity pass
+#
+# Only the setcap calls use sudo; the tests themselves run as the invoking
+# user. Usage: ./scripts/test_ebpf_caps.sh [--with-root]
+
+set -uo pipefail
+
+CAPS="cap_bpf,cap_perfmon,cap_dac_read_search=ep"
+WITH_ROOT=0
+[[ "${1:-}" == "--with-root" ]] && WITH_ROOT=1
+
+if [[ $EUID -eq 0 ]]; then
+    echo "error: run as a regular user (Phase A must be unprivileged); sudo is used only for setcap" >&2
+    exit 1
+fi
+
+# --- preflight ---------------------------------------------------------------
+KERNEL_MAJ_MIN=$(uname -r | cut -d. -f1-2)
+if ! awk -v v="$KERNEL_MAJ_MIN" 'BEGIN{split(v,a,"."); exit !(a[1]>5 || (a[1]==5 && a[2]>=8))}'; then
+    echo "warn: kernel $KERNEL_MAJ_MIN < 5.8 — CAP_BPF/CAP_PERFMON unavailable, Phase B will fail" >&2
+fi
+PARANOID=$(sysctl -n kernel.perf_event_paranoid 2>/dev/null || echo "?")
+if [[ "$PARANOID" != "?" && "$PARANOID" -ge 3 ]]; then
+    echo "warn: kernel.perf_event_paranoid=$PARANOID — the Ubuntu >=3 patch can block" >&2
+    echo "      perf_event_open even with CAP_PERFMON; Phase B may fail" >&2
+fi
+
+# --- locate test binary ------------------------------------------------------
+echo "building test binary..."
+BIN=$(cargo test --features ebpf --test ebpf_net_monitor_tests --no-run --message-format=json 2>/dev/null \
+    | jq -r 'select(.executable != null and .target.name == "ebpf_net_monitor_tests") | .executable')
+if [[ -z "$BIN" || ! -x "$BIN" ]]; then
+    echo "error: could not locate ebpf_net_monitor_tests binary" >&2
+    exit 1
+fi
+echo "test binary: $BIN"
+
+cleanup() { sudo setcap -r "$BIN" 2>/dev/null || true; }
+trap cleanup EXIT
+
+FAILED=0
+LOG=$(mktemp)
+report() { # name, exit_code — on failure, show the test output
+    if [[ $2 -eq 0 ]]; then
+        echo "PASS  $1"
+    else
+        echo "FAIL  $1"
+        sed 's/^/      /' "$LOG"
+        FAILED=1
+    fi
+}
+
+# --- Phase A: no caps → graceful degradation --------------------------------
+sudo setcap -r "$BIN" 2>/dev/null || true
+DENET_EXPECT_EBPF_DENIED=1 "$BIN" test_net_monitor_graceful_degradation >"$LOG" 2>&1
+report "Phase A: no caps degrades gracefully" $?
+
+# --- Phase B: caps without root → real data ----------------------------------
+echo "granting $CAPS (sudo)..."
+if sudo setcap "$CAPS" "$BIN"; then
+    DENET_EXPECT_EBPF=1 "$BIN" --include-ignored >"$LOG" 2>&1
+    report "Phase B: caps without root, all tests incl. privileged" $?
+else
+    echo "FAIL  Phase B: setcap failed"; FAILED=1
+fi
+
+# --- Phase C: root (optional) -------------------------------------------------
+if [[ $WITH_ROOT -eq 1 ]]; then
+    sudo setcap -r "$BIN" 2>/dev/null || true
+    sudo DENET_EXPECT_EBPF=1 "$BIN" --include-ignored >"$LOG" 2>&1
+    report "Phase C: root, all tests incl. privileged" $?
+fi
+rm -f "$LOG"
+
+exit $FAILED

--- a/src/core/process_monitor.rs
+++ b/src/core/process_monitor.rs
@@ -261,6 +261,8 @@ pub struct ProcessMonitor {
     ebpf_tracker: Option<crate::ebpf::SyscallTracker>,
     #[cfg(feature = "ebpf")]
     offcpu_profiler: Option<crate::ebpf::OffCpuProfiler>,
+    #[cfg(feature = "ebpf")]
+    net_monitor: Option<crate::ebpf::NetMonitor>,
     last_refresh_time: Instant,
     #[cfg(target_os = "linux")]
     cpu_sampler: crate::cpu_sampler::CpuSampler,
@@ -348,6 +350,8 @@ impl ProcessMonitor {
             ebpf_tracker: None,
             #[cfg(feature = "ebpf")]
             offcpu_profiler: None,
+            #[cfg(feature = "ebpf")]
+            net_monitor: None,
             last_refresh_time: now,
             #[cfg(target_os = "linux")]
             cpu_sampler: crate::cpu_sampler::CpuSampler::new(),
@@ -442,6 +446,8 @@ impl ProcessMonitor {
             ebpf_tracker: None,
             #[cfg(feature = "ebpf")]
             offcpu_profiler: None,
+            #[cfg(feature = "ebpf")]
+            net_monitor: None,
             last_refresh_time: now,
             #[cfg(target_os = "linux")]
             cpu_sampler: crate::cpu_sampler::CpuSampler::new(),
@@ -568,7 +574,7 @@ impl ProcessMonitor {
             }
 
             // Initialize off-CPU profiler
-            match crate::ebpf::OffCpuProfiler::new(pids) {
+            match crate::ebpf::OffCpuProfiler::new(pids.clone()) {
                 Ok(mut profiler) => {
                     if self.debug_mode {
                         profiler.enable_debug_mode();
@@ -578,6 +584,18 @@ impl ProcessMonitor {
                 }
                 Err(e) => {
                     log::warn!("Failed to enable off-CPU profiler: {}", e);
+                }
+            }
+
+            // Initialize per-process network monitor (infallible: degrades to
+            // an error string in metrics if kprobes can't attach)
+            match crate::ebpf::NetMonitor::new(pids) {
+                Ok(monitor) => {
+                    self.net_monitor = Some(monitor);
+                    log::info!("Network monitor enabled");
+                }
+                Err(e) => {
+                    log::warn!("Failed to enable network monitor: {}", e);
                 }
             }
 
@@ -1164,6 +1182,12 @@ impl ProcessMonitor {
                         if !stats.is_empty() {
                             ebpf_metrics.offcpu = Some(build_offcpu_metrics(&stats));
                         }
+                    }
+
+                    // Collect per-process network bytes
+                    if let Some(ref mut monitor) = self.net_monitor {
+                        monitor.update_pids(&all_pids);
+                        ebpf_metrics.network = Some(monitor.get_metrics());
                     }
 
                     agg.ebpf = Some(ebpf_metrics);

--- a/src/ebpf/metrics.rs
+++ b/src/ebpf/metrics.rs
@@ -14,7 +14,29 @@ pub struct EbpfMetrics {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub offcpu: Option<OffCpuMetrics>,
 
+    /// Per-process network byte counts (TCP + UDP, via kprobes)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<NetworkMetrics>,
+
     /// Error message if eBPF collection failed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Per-process network byte counts collected via eBPF kprobes.
+/// Cumulative since attach (including exited children), attributed to the
+/// monitored process tree — unlike the procfs-based `sys_net_*` fields,
+/// which are system-wide. Covers TCP (v4/v6) and UDP (v4); RX counts bytes
+/// returned to userspace, TX counts bytes requested at the socket layer.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NetworkMetrics {
+    /// Bytes received by the monitored processes
+    pub rx_bytes: u64,
+
+    /// Bytes sent by the monitored processes
+    pub tx_bytes: u64,
+
+    /// Error message if collection failed (e.g. kprobe attach denied)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -23,9 +45,8 @@ impl EbpfMetrics {
     /// Create metrics with an error message
     pub fn error(message: &str) -> Self {
         Self {
-            syscalls: None,
-            offcpu: None,
             error: Some(message.to_string()),
+            ..Default::default()
         }
     }
 
@@ -33,17 +54,15 @@ impl EbpfMetrics {
     pub fn with_syscalls(syscalls: SyscallMetrics) -> Self {
         Self {
             syscalls: Some(syscalls),
-            offcpu: None,
-            error: None,
+            ..Default::default()
         }
     }
 
     /// Create metrics with off-CPU profiling data
     pub fn with_offcpu(offcpu: OffCpuMetrics) -> Self {
         Self {
-            syscalls: None,
             offcpu: Some(offcpu),
-            error: None,
+            ..Default::default()
         }
     }
 
@@ -52,7 +71,7 @@ impl EbpfMetrics {
         Self {
             syscalls: Some(syscalls),
             offcpu: Some(offcpu),
-            error: None,
+            ..Default::default()
         }
     }
 

--- a/src/ebpf/mod.rs
+++ b/src/ebpf/mod.rs
@@ -11,6 +11,8 @@ pub mod memory_map_cache;
 #[cfg(target_os = "linux")]
 pub mod metrics;
 #[cfg(target_os = "linux")]
+pub mod net_monitor;
+#[cfg(target_os = "linux")]
 pub mod offcpu_profiler;
 #[cfg(target_os = "linux")]
 pub mod syscall_tracker;
@@ -21,6 +23,8 @@ pub use metrics::*;
 pub use debug::debug_println;
 #[cfg(target_os = "linux")]
 pub use memory_map_cache::MemoryMapCache;
+#[cfg(target_os = "linux")]
+pub use net_monitor::NetMonitor;
 #[cfg(target_os = "linux")]
 pub use offcpu_profiler::{OffCpuProfiler, OffCpuStats};
 #[cfg(target_os = "linux")]

--- a/src/ebpf/net_monitor.rs
+++ b/src/ebpf/net_monitor.rs
@@ -1,0 +1,235 @@
+//! Per-process network byte accounting using eBPF kprobes
+//!
+//! Rust counterpart to `net_monitor.c`: loads the program, seeds the
+//! BPF-side PID filter, attaches the TCP/UDP kprobes, and reads cumulative
+//! per-tgid byte counts. Unlike the procfs `sys_net_*` path (system-wide),
+//! these bytes are attributed to the monitored process tree.
+//!
+//! Degradation contract: the constructor never fails hard. Load/attach
+//! errors (missing capabilities, locked-down kernel) surface as an error
+//! string in the returned metrics, and all methods become safe no-ops.
+
+use crate::ebpf::metrics::NetworkMetrics;
+use crate::error::{DenetError, Result};
+use std::collections::HashSet;
+
+use aya::{maps::HashMap as BpfHashMap, programs::KProbe, Ebpf};
+
+// 8-byte alignment required by the `object` crate's ELF parser (it casts the
+// slice directly to FileHeader64). Same pattern as syscall_tracker.rs.
+#[repr(align(8))]
+struct AlignedBytes<const N: usize>([u8; N]);
+
+static NET_MONITOR_BYTECODE_ALIGNED: AlignedBytes<
+    { include_bytes!(concat!(env!("OUT_DIR"), "/ebpf/net_monitor.o")).len() },
+> = AlignedBytes(*include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/ebpf/net_monitor.o"
+)));
+
+const NET_MONITOR_BYTECODE: &[u8] = &NET_MONITOR_BYTECODE_ALIGNED.0;
+
+// Map value layout: [rx_bytes, tx_bytes]. Matches struct net_bytes_val in
+// net_monitor.c; a plain array keeps aya's Pod requirement satisfied for free.
+type NetBytesMap = BpfHashMap<aya::maps::MapData, u32, [u64; 2]>;
+type PidFilterMap = BpfHashMap<aya::maps::MapData, u32, u8>;
+
+/// Per-process network byte monitor (TCP v4/v6 + UDP v4).
+pub struct NetMonitor {
+    _bpf: Option<Ebpf>,
+    net_bytes: Option<NetBytesMap>,
+    pid_filter: Option<PidFilterMap>,
+    monitored_pids: HashSet<u32>,
+    /// Bytes from pids that exited: folded in before their map entries are
+    /// deleted, so cumulative totals never regress.
+    retired_rx: u64,
+    retired_tx: u64,
+    init_error: Option<String>,
+}
+
+impl std::fmt::Debug for NetMonitor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NetMonitor")
+            .field("bpf_loaded", &self._bpf.is_some())
+            .field("monitored_pids", &self.monitored_pids)
+            .field("init_error", &self.init_error)
+            .finish()
+    }
+}
+
+impl NetMonitor {
+    /// Create a monitor for the given process tree. Never fails hard: on
+    /// load/attach errors the monitor degrades to reporting the error via
+    /// metrics.
+    pub fn new(pids: Vec<u32>) -> Result<Self> {
+        let monitored_pids: HashSet<u32> = pids.into_iter().collect();
+        match Self::init_ebpf(&monitored_pids) {
+            Ok((bpf, net_bytes, pid_filter)) => {
+                log::info!("eBPF net monitor initialized");
+                Ok(Self {
+                    _bpf: Some(bpf),
+                    net_bytes: Some(net_bytes),
+                    pid_filter: Some(pid_filter),
+                    monitored_pids,
+                    retired_rx: 0,
+                    retired_tx: 0,
+                    init_error: None,
+                })
+            }
+            Err(e) => {
+                log::warn!("eBPF net monitor unavailable: {}", e);
+                Ok(Self {
+                    _bpf: None,
+                    net_bytes: None,
+                    pid_filter: None,
+                    monitored_pids,
+                    retired_rx: 0,
+                    retired_tx: 0,
+                    init_error: Some(e.to_string()),
+                })
+            }
+        }
+    }
+
+    fn init_ebpf(pids: &HashSet<u32>) -> Result<(Ebpf, NetBytesMap, PidFilterMap)> {
+        let mut bpf = Ebpf::load(NET_MONITOR_BYTECODE).map_err(|e| {
+            DenetError::EbpfInitError(format!("failed to load net_monitor bytecode: {}", e))
+        })?;
+
+        // Seed the PID filter BEFORE attaching: maps exist after Ebpf::load,
+        // so there is no window where probes run against an empty filter and
+        // monitored bytes are dropped.
+        let mut pid_filter: PidFilterMap = bpf
+            .take_map("pid_filter")
+            .ok_or_else(|| DenetError::EbpfInitError("pid_filter map not found".to_string()))
+            .and_then(|m| {
+                BpfHashMap::try_from(m).map_err(|e| {
+                    DenetError::EbpfInitError(format!("pid_filter map has unexpected shape: {}", e))
+                })
+            })?;
+        for pid in pids {
+            pid_filter.insert(pid, 1, 0).map_err(|e| {
+                DenetError::EbpfInitError(format!("failed to seed pid_filter: {}", e))
+            })?;
+        }
+
+        for (prog_name, fn_name) in [
+            ("trace_tcp_sendmsg", "tcp_sendmsg"),
+            ("trace_tcp_recvmsg_ret", "tcp_recvmsg"),
+            ("trace_udp_sendmsg", "udp_sendmsg"),
+            ("trace_udp_recvmsg_ret", "udp_recvmsg"),
+        ] {
+            let program: &mut KProbe = bpf
+                .program_mut(prog_name)
+                .ok_or_else(|| {
+                    DenetError::EbpfInitError(format!(
+                        "program {} not found in bytecode",
+                        prog_name
+                    ))
+                })?
+                .try_into()
+                .map_err(|e| {
+                    DenetError::EbpfInitError(format!("{} is not a kprobe: {}", prog_name, e))
+                })?;
+            program.load().map_err(|e| {
+                DenetError::EbpfInitError(format!("failed to load {}: {}", prog_name, e))
+            })?;
+            program.attach(fn_name, 0).map_err(|e| {
+                DenetError::EbpfInitError(format!(
+                    "failed to attach {} to {}: {}",
+                    prog_name, fn_name, e
+                ))
+            })?;
+        }
+
+        let net_bytes = bpf
+            .take_map("net_bytes")
+            .ok_or_else(|| DenetError::EbpfInitError("net_bytes map not found".to_string()))
+            .and_then(|m| {
+                BpfHashMap::try_from(m).map_err(|e| {
+                    DenetError::EbpfInitError(format!("net_bytes map has unexpected shape: {}", e))
+                })
+            })?;
+
+        Ok((bpf, net_bytes, pid_filter))
+    }
+
+    /// Sync the BPF-side PID filter with the current process tree. Bytes of
+    /// pids that left the tree are folded into the retired accumulators
+    /// before their map entries are removed, keeping totals monotonic.
+    /// Safe no-op when degraded.
+    pub fn update_pids(&mut self, pids: &[u32]) {
+        let (Some(net_bytes), Some(pid_filter)) =
+            (self.net_bytes.as_mut(), self.pid_filter.as_mut())
+        else {
+            return;
+        };
+
+        let new: HashSet<u32> = pids.iter().copied().collect();
+        for gone in self.monitored_pids.difference(&new) {
+            if let Ok([rx, tx]) = net_bytes.get(gone, 0) {
+                self.retired_rx += rx;
+                self.retired_tx += tx;
+            }
+            let _ = net_bytes.remove(gone);
+            let _ = pid_filter.remove(gone);
+        }
+        for added in new.difference(&self.monitored_pids) {
+            if let Err(e) = pid_filter.insert(added, 1, 0) {
+                log::warn!("failed to add pid {} to net filter: {}", added, e);
+            }
+        }
+        self.monitored_pids = new;
+    }
+
+    /// Cumulative bytes for the monitored tree since attach, including
+    /// already-exited pids. The BPF-side filter guarantees every map entry
+    /// belongs to the tree, so the whole map is summed.
+    pub fn get_metrics(&self) -> NetworkMetrics {
+        let Some(ref map) = self.net_bytes else {
+            return NetworkMetrics {
+                rx_bytes: 0,
+                tx_bytes: 0,
+                error: self.init_error.clone(),
+            };
+        };
+
+        let (mut rx, mut tx) = (self.retired_rx, self.retired_tx);
+        for (_tgid, [r, t]) in map.iter().flatten() {
+            rx += r;
+            tx += t;
+        }
+        NetworkMetrics {
+            rx_bytes: rx,
+            tx_bytes: tx,
+            error: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_net_monitor_creation_is_infallible() {
+        // Must construct without error even unprivileged: load/attach failures
+        // surface through metrics.error, never a panic or Err.
+        let monitor = NetMonitor::new(vec![std::process::id()]).unwrap();
+        let metrics = monitor.get_metrics();
+        if metrics.error.is_some() {
+            assert_eq!(metrics.rx_bytes, 0);
+            assert_eq!(metrics.tx_bytes, 0);
+        }
+    }
+
+    #[test]
+    fn test_update_pids_safe_when_degraded() {
+        let mut monitor = NetMonitor::new(vec![1]).unwrap();
+        // Regardless of privilege, repeated update/get must not panic.
+        monitor.update_pids(&[1, 2, 3]);
+        monitor.update_pids(&[3]);
+        let _ = monitor.get_metrics();
+        let _ = monitor.get_metrics();
+    }
+}

--- a/src/ebpf/programs/net_monitor.c
+++ b/src/ebpf/programs/net_monitor.c
@@ -1,0 +1,99 @@
+//! Per-process network byte accounting eBPF program
+//!
+//! Attaches kprobes to the socket-layer send/recv paths so that
+//! bpf_get_current_pid_tgid() runs in process context and bytes are
+//! attributed to the owning process (net_dev tracepoints fire in softirq
+//! context, where the current task is unrelated to RX traffic).
+//!
+//! Covered: TCP (v4+v6, both share tcp_sendmsg/tcp_recvmsg) and UDP v4.
+//! UDP over IPv6 uses udpv6_sendmsg/udpv6_recvmsg and is not counted.
+//!
+//! TX counts bytes requested at the socket layer (send failures overcount
+//! slightly); RX counts bytes actually returned to userspace.
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <linux/ptrace.h>
+#include <linux/types.h>
+
+typedef __u32 u32;
+typedef __u64 u64;
+typedef __u8 u8;
+
+struct net_bytes_val {
+    u64 rx;
+    u64 tx;
+};
+
+// tgid → monitored flag. Seeded before attach and synced from userspace
+// each sample, so only the monitored process tree is accounted.
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, u8);
+    __uint(max_entries, 1024);
+} pid_filter SEC(".maps");
+
+// tgid → cumulative bytes. Bounded by monitored-tree size, not host load.
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, struct net_bytes_val);
+    __uint(max_entries, 1024);
+} net_bytes SEC(".maps");
+
+static __always_inline void add_bytes(u64 rx, u64 tx)
+{
+    u32 tgid = bpf_get_current_pid_tgid() >> 32;
+    if (!bpf_map_lookup_elem(&pid_filter, &tgid))
+        return;
+
+    struct net_bytes_val *val = bpf_map_lookup_elem(&net_bytes, &tgid);
+    if (val) {
+        __sync_fetch_and_add(&val->rx, rx);
+        __sync_fetch_and_add(&val->tx, tx);
+    } else {
+        struct net_bytes_val init = { .rx = rx, .tx = tx };
+        bpf_map_update_elem(&net_bytes, &tgid, &init, BPF_ANY);
+    }
+}
+
+// int tcp_sendmsg(struct sock *sk, struct msghdr *msg, size_t size)
+SEC("kprobe/tcp_sendmsg")
+int trace_tcp_sendmsg(struct pt_regs *ctx)
+{
+    add_bytes(0, PT_REGS_PARM3(ctx));
+    return 0;
+}
+
+// tcp_recvmsg/udp_recvmsg return bytes copied to userspace (or <0 on error).
+// Both return int: on x86-64 only the low 32 bits of rax are defined, the
+// upper half is garbage — truncate before the sign check or we sum junk.
+SEC("kretprobe/tcp_recvmsg")
+int trace_tcp_recvmsg_ret(struct pt_regs *ctx)
+{
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret > 0)
+        add_bytes(ret, 0);
+    return 0;
+}
+
+// int udp_sendmsg(struct sock *sk, struct msghdr *msg, size_t len)
+SEC("kprobe/udp_sendmsg")
+int trace_udp_sendmsg(struct pt_regs *ctx)
+{
+    add_bytes(0, PT_REGS_PARM3(ctx));
+    return 0;
+}
+
+SEC("kretprobe/udp_recvmsg")
+int trace_udp_recvmsg_ret(struct pt_regs *ctx)
+{
+    int ret = (int)PT_REGS_RC(ctx);
+    if (ret > 0)
+        add_bytes(ret, 0);
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/tests/ebpf_net_monitor_tests.rs
+++ b/tests/ebpf_net_monitor_tests.rs
@@ -1,0 +1,203 @@
+//! Integration tests for eBPF per-process network byte accounting.
+//!
+//! Two tiers:
+//! - `test_net_monitor_graceful_degradation` always runs (unprivileged OK).
+//!   Env hooks let scripts/test_ebpf_caps.sh pin the expected mode:
+//!   DENET_EXPECT_EBPF_DENIED=1 asserts degradation actually happened,
+//!   DENET_EXPECT_EBPF=1 asserts real eBPF data is flowing.
+//! - `*_privileged` tests are #[ignore]d; they need CAP_BPF+CAP_PERFMON or
+//!   root. Run via scripts/test_ebpf_caps.sh or:
+//!   sudo -E cargo test --features ebpf --test ebpf_net_monitor_tests -- --ignored
+#![cfg(all(target_os = "linux", feature = "ebpf"))]
+
+use denet::ebpf::NetMonitor;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream, UdpSocket};
+
+fn own_pid() -> u32 {
+    std::process::id()
+}
+
+/// Privileged tests measure this process's real traffic, so concurrent test
+/// bodies would pollute each other's byte counts. Serialize them.
+static NET_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn net_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    NET_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[test]
+fn test_net_monitor_graceful_degradation() {
+    // Constructor is infallible regardless of privilege.
+    let mut monitor = NetMonitor::new(vec![own_pid()]).expect("constructor must not fail");
+    let metrics = monitor.get_metrics();
+
+    if std::env::var("DENET_EXPECT_EBPF_DENIED").as_deref() == Ok("1") {
+        assert!(
+            metrics.error.is_some(),
+            "expected degradation (no caps), but eBPF attached: {:?}",
+            metrics
+        );
+    }
+    if std::env::var("DENET_EXPECT_EBPF").as_deref() == Ok("1") {
+        assert!(
+            metrics.error.is_none(),
+            "expected working eBPF, got error: {:?}",
+            metrics.error
+        );
+    }
+
+    if metrics.error.is_some() {
+        // Degraded mode: zeros, and every method is a safe no-op.
+        assert_eq!(metrics.rx_bytes, 0);
+        assert_eq!(metrics.tx_bytes, 0);
+        monitor.update_pids(&[own_pid(), 1]);
+        monitor.update_pids(&[own_pid()]);
+        let _ = monitor.get_metrics();
+    }
+
+    // JSON shape pin: rx/tx always present, error only when set.
+    let json = serde_json::to_value(&metrics).unwrap();
+    assert!(json.get("rx_bytes").is_some());
+    assert!(json.get("tx_bytes").is_some());
+    assert_eq!(json.get("error").is_some(), metrics.error.is_some());
+}
+
+/// Transfer `total` bytes over localhost TCP within this process, so both
+/// endpoints belong to our tgid and rx/tx both see the payload.
+fn tcp_localhost_transfer(total: usize) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let reader = std::thread::spawn(move || {
+        let (mut conn, _) = listener.accept().unwrap();
+        let mut buf = [0u8; 64 * 1024];
+        let mut seen = 0usize;
+        loop {
+            match conn.read(&mut buf).unwrap() {
+                0 => break,
+                n => seen += n,
+            }
+        }
+        seen
+    });
+
+    let mut stream = TcpStream::connect(addr).unwrap();
+    let chunk = [0xABu8; 64 * 1024];
+    let mut sent = 0usize;
+    while sent < total {
+        let n = chunk.len().min(total - sent);
+        stream.write_all(&chunk[..n]).unwrap();
+        sent += n;
+    }
+    drop(stream);
+    assert_eq!(reader.join().unwrap(), total);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF+CAP_PERFMON; run scripts/test_ebpf_caps.sh or sudo -E cargo test -- --ignored"]
+fn test_net_monitor_tcp_localhost_privileged() {
+    let _guard = net_test_guard();
+    const TOTAL: u64 = 5 * 1024 * 1024;
+    const SLOP: u64 = 1024 * 1024;
+
+    let monitor = NetMonitor::new(vec![own_pid()]).unwrap();
+    let probe = monitor.get_metrics();
+    assert!(
+        probe.error.is_none(),
+        "eBPF attach failed: {:?}",
+        probe.error
+    );
+
+    tcp_localhost_transfer(TOTAL as usize);
+
+    let m = monitor.get_metrics();
+    assert!(
+        m.tx_bytes >= TOTAL && m.tx_bytes < TOTAL + SLOP,
+        "tx {} outside [{}, {})",
+        m.tx_bytes,
+        TOTAL,
+        TOTAL + SLOP
+    );
+    assert!(
+        m.rx_bytes >= TOTAL && m.rx_bytes < TOTAL + SLOP,
+        "rx {} outside [{}, {})",
+        m.rx_bytes,
+        TOTAL,
+        TOTAL + SLOP
+    );
+}
+
+#[test]
+#[ignore = "needs CAP_BPF+CAP_PERFMON; run scripts/test_ebpf_caps.sh or sudo -E cargo test -- --ignored"]
+fn test_net_monitor_udp_localhost_privileged() {
+    let _guard = net_test_guard();
+    const DATAGRAMS: usize = 1024;
+    const SIZE: usize = 1024;
+    const TOTAL: u64 = (DATAGRAMS * SIZE) as u64;
+    const SLOP: u64 = 256 * 1024;
+
+    let monitor = NetMonitor::new(vec![own_pid()]).unwrap();
+    let probe = monitor.get_metrics();
+    assert!(
+        probe.error.is_none(),
+        "eBPF attach failed: {:?}",
+        probe.error
+    );
+
+    let rx_sock = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let tx_sock = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let dst = rx_sock.local_addr().unwrap();
+    let payload = [0xCDu8; SIZE];
+    let mut buf = [0u8; SIZE];
+    for _ in 0..DATAGRAMS {
+        tx_sock.send_to(&payload, dst).unwrap();
+        // Blocking recv of each datagram: loopback UDP is lossless and
+        // ordered, and this keeps the socket buffer from overflowing.
+        let (n, _) = rx_sock.recv_from(&mut buf).unwrap();
+        assert_eq!(n, SIZE);
+    }
+
+    let m = monitor.get_metrics();
+    assert!(
+        m.tx_bytes >= TOTAL && m.tx_bytes < TOTAL + SLOP,
+        "udp tx {} outside [{}, {})",
+        m.tx_bytes,
+        TOTAL,
+        TOTAL + SLOP
+    );
+    assert!(
+        m.rx_bytes >= TOTAL && m.rx_bytes < TOTAL + SLOP,
+        "udp rx {} outside [{}, {})",
+        m.rx_bytes,
+        TOTAL,
+        TOTAL + SLOP
+    );
+}
+
+#[test]
+#[ignore = "needs CAP_BPF+CAP_PERFMON; run scripts/test_ebpf_caps.sh or sudo -E cargo test -- --ignored"]
+fn test_net_monitor_pid_filter_excludes_others_privileged() {
+    let _guard = net_test_guard();
+    // Monitor pid 1 (init) — our own traffic must NOT be accounted, proving
+    // the filter runs BPF-side rather than in userspace post-filtering.
+    let monitor = NetMonitor::new(vec![1]).unwrap();
+    let probe = monitor.get_metrics();
+    assert!(
+        probe.error.is_none(),
+        "eBPF attach failed: {:?}",
+        probe.error
+    );
+
+    tcp_localhost_transfer(1024 * 1024);
+
+    let m = monitor.get_metrics();
+    // pid 1 may do minor network I/O of its own (systemd); allow a small
+    // budget rather than assert an exact zero.
+    assert!(
+        m.rx_bytes < 64 * 1024 && m.tx_bytes < 64 * 1024,
+        "filter leak: our 1MB transfer showed up under pid 1: {:?}",
+        m
+    );
+}


### PR DESCRIPTION
Adds real per-process network metrics via eBPF kprobes on `tcp/udp_sendmsg` + `recvmsg` — bytes are attributed by the kernel to the monitored process tree, unlike the system-wide procfs `sys_net_*` fields (which remain as fallback).

- BPF-side PID filter, seeded before attach and synced per sample; maps bounded by tree size
- Totals are monotonic: exited children fold into retired accumulators
- TCP v4/v6 + UDP v4; RX = bytes returned to userspace, TX = bytes requested (docs/ebpf.md)
- JSON: `ebpf.network.{rx_bytes,tx_bytes}` — no Python binding changes needed
- Tests: unprivileged graceful-degradation (CI-safe) + 3 `#[ignore]`d privileged tests; `scripts/test_ebpf_caps.sh` exercises the capability matrix (no caps → degrades with error string; `cap_bpf,cap_perfmon,cap_dac_read_search` without root → real data). Both phases verified locally, plus a 10 MB download attributing rx=10,019,992

Release-As: 0.8.0