### PR TITLE
feat(report): static HTML/PNG/SVG report with regime detection 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,12 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install maturin twine
 
+      - name: Install eBPF build deps
+        # clang compiles the BPF programs baked into the Linux wheel (libbpf
+        # headers are vendored, so no -dev package needed). Runtime needs no
+        # clang — only CAP_BPF to actually attach.
+        run: sudo apt-get update && sudo apt-get install -y clang llvm
+
       - name: Update version if provided
         if: github.event.inputs.version != ''
         run: |
@@ -45,9 +51,14 @@ jobs:
         env:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
         run: |
-          # abi3 wheel (one wheel for py3.9+, incl. 3.13/3.14) + sdist
-          # so systems with older glibc than the manylinux wheel can build.
-          maturin build --release --sdist
+          # Linux abi3 wheel (one wheel for py3.9+) WITH eBPF, so Linux pip
+          # users get per-process metrics without a source build. aya is pure
+          # Rust — no new shared-lib deps, manylinux compat unchanged.
+          maturin build --release --features python,ebpf
+          # sdist stays eBPF-free: it's the fallback macOS/other platforms build
+          # from, where the BPF toolchain isn't assumed. Its features come from
+          # pyproject ([tool.maturin] features = ["python"]) at build time.
+          maturin sdist
 
       - name: List built packages
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,11 +131,20 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install maturin twine pytest
 
+      - name: Install eBPF build deps (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y clang llvm
+
       - name: Build wheels
         env:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
         run: |
-          maturin build --release
+          # Linux wheels ship eBPF; macOS wheels stay python-only (no BPF toolchain).
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            maturin build --release --features python,ebpf
+          else
+            maturin build --release
+          fi
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__/*
 
 out.json
 scripts/*.png
+
+# scanpy example downloads its dataset here
+python/examples/data/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "denet"
 version = "0.7.2"
+default-run = "denet"
 edition = "2021"
 description = "a simple process monitor"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ denet attach 1234
 
 # Save metrics as JSONL
 denet --json --out metrics.jsonl run python train.py
+
+# Turn a saved run into a report (timelines, regime detection, eBPF syscalls)
+pip install denet[report]
+denet-report metrics.jsonl -o report.html
 ```
 
 CPU usage follows the `top` convention: 100% = one fully utilized core, so a 4-core workload shows 400%.
@@ -60,6 +64,7 @@ denet -i 50 -m 500 run python train.py
 | Topic | Doc |
 |---|---|
 | Python API (`ProcessMonitor`, `execute_with_monitoring`, analysis) | [docs/python-api.md](docs/python-api.md) |
+| HTML/PNG/SVG reports (`denet-report`) | [docs/python-api.md#reports](docs/python-api.md#reports) |
 | GPU monitoring | [docs/gpu.md](docs/gpu.md) |
 | eBPF profiling (off-CPU, syscall tracking) | [docs/ebpf.md](docs/ebpf.md) |
 | Disk I/O metrics and how to interpret them | [docs/disk-io.md](docs/disk-io.md) |

--- a/docs/ebpf.md
+++ b/docs/ebpf.md
@@ -302,6 +302,13 @@ attributable to a live PID, omitted while zero. The three reconcile exactly:
 up to the totals. If eBPF could not attach (missing capabilities), the object
 carries an `error` string instead of silently reporting zeros as real data.
 
+**From Python:** pass `enable_ebpf=True` to `execute_with_monitoring` (or the
+`ProcessMonitor` constructors). This only does anything when the extension was
+built with the eBPF feature — the published wheels are eBPF-free, so build it
+yourself on Linux with `pixi run develop-ebpf` (needs clang). Without the
+feature, or without capabilities, the flag degrades to a logged warning. See
+`python/examples/network_children.sh` for an end-to-end run.
+
 **Required capabilities** are the same as the rest of the eBPF features
 (`cap_bpf,cap_perfmon,cap_dac_read_search` — see above). To verify the whole
 capability matrix, including graceful degradation without caps and real data

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -151,3 +151,64 @@ tree_analysis = denet.process_tree_analysis(metrics)
 # Example: Analyze CPU usage from multi-process workload
 # See scripts/analyze_cpu.py for detailed CPU analysis example
 ```
+
+## Reports
+
+Generate a report (CPU / memory / network timelines rendered with Vega-Lite)
+from a saved JSONL file. Requires the `report` extra:
+
+```bash
+pip install denet[report]
+denet-report metrics.jsonl                 # -> metrics.html (interactive, default)
+denet-report metrics.jsonl -o out.png      # static PNG (format from extension)
+denet-report metrics.jsonl -f svg -o r.svg # static SVG
+```
+
+`denet-report` is a console entry point installed with the package; `python -m
+denet.report ...` is equivalent. Run `denet-report --help` for the full option
+list.
+
+Or from Python:
+
+```python
+import denet
+denet.generate_report("metrics.jsonl", "report.html")     # default html
+denet.generate_report("metrics.jsonl", "report.png")      # format inferred from extension
+denet.generate_report("metrics.jsonl", fmt="svg")         # explicit format
+```
+
+**Output formats** (`-f/--format`, default `html`):
+
+| Format | Interactive? | Notes |
+|---|---|---|
+| `html` | yes (JavaScript) | Self-contained, open in a browser. The default. |
+| `png`  | no | Static raster; opens in any viewer, editor preview, or GitHub. |
+| `svg`  | no | Static vector; no JavaScript. |
+
+When `--format` is omitted it is inferred from the `-o` extension, falling back
+to `html`.
+
+The report header states which optional capabilities the run had (eBPF, PSI,
+perf counters) and whether network figures are per-process (eBPF) or the
+system-wide approximation. Long runs are downsampled to at most 512 time slots
+(mean for gauges, max for rates, so spikes survive).
+
+The report also runs **regime detection**: binary segmentation over the
+z-scored CPU / memory / network series splits the run into piecewise-constant
+phases (e.g. idle → compute → write-out). Detected regimes are shaded as
+alternating bands across the timelines and summarised in a table (span, mean
+CPU, mean RSS, dominant activity). Short runs (fewer than ~8 slots) are left
+unsegmented.
+
+Extra panels appear only when the run carries the data for them:
+
+- **Memory pressure (PSI)** — a `some`/`full` memory-stall timeline, shown
+  whenever PSI was recorded. A flat-zero trace is kept: "no memory pressure"
+  is itself a useful reading.
+- **Syscalls by category, per regime (eBPF)** — a normalized stacked bar of the
+  syscall mix (file_io / memory / network / …) for each regime, so you can see
+  how the syscall profile shifts between phases. Every regime stays on the axis
+  (an empty row means that phase made no tracked syscalls), and it is hidden
+  entirely when there is no eBPF syscall data. The per-sample counts are
+  alive-PID snapshots rather than clean per-window deltas, so the bar shows the
+  phase's typical *mix* (proportions), not absolute call totals.

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,4 +1,21 @@
-version: 6
+version: 7
+platforms:
+- name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
+- name: osx-64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=x86_64
+- name: osx-arm64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=m1
 environments:
   default:
     channels:
@@ -9,65 +26,84 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.9.0-py312h178313f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.49.2-hee588c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.8.6-py39h446a924_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.1-py312h33ff503_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py312h8ecdadd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py312h192e038_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.13-py312h1d08497_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/vl-convert-python-2.0.0rc1-py312h03c3619_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/altair-6.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-7_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.13-py312h1d08497_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.13.2-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       osx-64:
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/altair-6.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.9.2-py312h3520af0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.0-h240833e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.8.1-hd471939_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.2-he7d56d0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.8.6-py39h21b1788_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.1-hc426f3f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
@@ -75,38 +111,65 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.0-h30d4d87_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-7_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.12.2-h8aa17f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.9.2-py312h3520af0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-8_he492b99_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-8_h9b27e0a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.0-h240833e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-8_h859234e_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.8.1-hd471939_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.33-openmp_h9e49c7b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.3-h8f8c405_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py312heb39f77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.8.6-py39h21b1788_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.5.1-py312h746d82c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.1-hc426f3f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.3-py312h8e27051_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.0-h30d4d87_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-2026.6.3-py312hb77ea7e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.12.2-h8aa17f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/vl-convert-python-2.0.0rc1-py312h03bf33c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.8.1-h357f2ed_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-gpl-tools-5.8.1-h357f2ed_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.8.1-hd471939_2.conda
       osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/altair-6.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.9.0-py312h998013c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.1-h3f77e49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.8.6-py39h3b6e2d1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
@@ -114,17 +177,48 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-7_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.11.13-py312h846f395_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.9.0-py312h998013c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.1-h3f77e49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py312h04c11ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.8.6-py39h3b6e2d1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.1-py312ha003a3f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.3-py312h6510ced_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.6.3-py312h8b1d842_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.11.13-py312h846f395_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/vl-convert-python-2.0.0rc1-py312h2bbb03f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.1-h39f12f2_2.conda
@@ -161,25 +255,563 @@ packages:
   purls: []
   size: 252783
   timestamp: 1720974456583
-- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
-  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
-  md5: 7ed4301d437b59045be7e051a0308211
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.9.0-py312h178313f_0.conda
+  sha256: e490a0972f4b0740fa5d065532062e322d101de54f762d131651cbf3dd170ece
+  md5: f9527a9f8b6015f847cbf0a2be9b6a28
   depends:
-  - __osx >=10.13
-  license: bzip2-1.0.6
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - tomli
+  license: Apache-2.0
+  purls:
+  - pkg:pypi/coverage?source=hash-mapping
+  size: 373132
+  timestamp: 1749691837365
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
+  sha256: db73f38155d901a610b2320525b9dd3b31e4949215c870685fd92ea61b5ce472
+  md5: 01f8d123c96816249efd255a31ad7712
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - binutils_impl_linux-64 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 671240
+  timestamp: 1740155456116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+  build_number: 8
+  sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+  md5: 00fc660ab1b2f5ca07e92b4900d10c79
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - blas 2.308   openblas
+  - mkl <2027
+  - libcblas   3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
   license_family: BSD
-  size: 134188
-  timestamp: 1720974491916
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
-  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 18804
+  timestamp: 1779859100675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+  build_number: 8
+  sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+  md5: 33a413f1095f8325e5c30fde3b0d2445
   depends:
-  - __osx >=11.0
-  license: bzip2-1.0.6
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 18778
+  timestamp: 1779859107964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
+  sha256: 33ab03438aee65d6aa667cf7d90c91e5e7d734c19a67aa4c7040742c0a13d505
+  md5: db0bfbe7dd197b68ad5f30333bae6ce0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.7.0.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 74427
+  timestamp: 1743431794976
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+  sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
+  md5: ede4673863426c0883c0063d853bbd85
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 57433
+  timestamp: 1743434498161
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
+  sha256: 0024f9ab34c09629621aefd8603ef77bf9d708129b0dd79029e502c39ffc2195
+  md5: ea8ac52380885ed41c1baa8f1d6d2b93
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.1.0=*_2
+  - libgomp 15.1.0 h767d61c_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 829108
+  timestamp: 1746642191935
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
+  sha256: 0ab5421a89f090f3aa33841036bb3af4ed85e1f91315b528a9d75fab9aad51ae
+  md5: ddca86c7040dd0e73b2b69bd7833d225
+  depends:
+  - libgcc 15.1.0 h767d61c_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 34586
+  timestamp: 1746642200749
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_5.conda
+  sha256: 4c1a526198d0d62441549fdfd668cc8e18e77609da1e545bdcc771dd8dc6a990
+  md5: 0c91408b3dec0b97e8a3c694845bd63b
+  depends:
+  - libgfortran5 15.1.0 hcea5267_5
+  constrains:
+  - libgfortran-ng ==15.1.0=*_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 29169
+  timestamp: 1757042575979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_5.conda
+  sha256: 9d06adc6d8e8187ddc1cad87525c690bc8202d8cb06c13b76ab2fc80a35ed565
+  md5: fbd4008644add05032b6764807ee2cba
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.1.0
+  constrains:
+  - libgfortran 15.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 1564589
+  timestamp: 1757042559498
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
+  sha256: 05fff3dc7e80579bc28de13b511baec281c4343d703c406aefd54389959154fb
+  md5: fbe7d535ff9d3a168c148e07358cd5b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 452635
+  timestamp: 1746642113092
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+  build_number: 8
+  sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+  md5: 809be8ba8712c77bc7d44c2d99390dc4
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - libcblas   3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 18790
+  timestamp: 1779859115086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
+  sha256: eeff241bddc8f1b87567dd6507c9f441f7f472c27f0860a07628260c000ef27c
+  md5: a76fd702c93cd2dfd89eff30a5fd45a8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
+  license: 0BSD
+  purls: []
+  size: 112845
+  timestamp: 1746531470399
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_1.conda
+  sha256: f157a2da5f7bf2c5ce5a18c52ccc76c39f075f7fbb1584d585a8d25c1b17cb92
+  md5: 5499e2dd2f567a818b9f111e47caebd2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_1
+  license: 0BSD
+  purls: []
+  size: 441592
+  timestamp: 1746531484594
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  purls: []
+  size: 33408
+  timestamp: 1697359010159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+  sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
+  md5: 2d3278b721e40468295ca755c3b84070
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.33,<0.3.34.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libopenblas >=0.3.33,<1.0a0
+  size: 5931919
+  timestamp: 1776993658641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
+  sha256: 365376f4815e5e80def2b3462a2419708b7c292da0da85278386c2618621fff4
+  md5: 4aed8e657e9ff156bdbe849b4df44389
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  run_exports:
+    weak:
+    - libsqlite >=3.53.3,<4.0a0
+  size: 962119
+  timestamp: 1782519076616
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
+  sha256: 6ae3d153e78f6069d503d9309f2cac6de5b93d067fc6433160a4c05226a5dad4
+  md5: 1cb1c67961f6dd257eae9e9691b341aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.1.0 h767d61c_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 3902355
+  timestamp: 1746642227493
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 122909
-  timestamp: 1720974522888
+  size: 33601
+  timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 63629
+  timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+  sha256: 5f3aad1f3a685ed0b591faad335957dbdb1b73abfd6fc731a0d42718e0653b33
+  md5: 93a4752d42b12943a355b682ee43285b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 26057
+  timestamp: 1772445297924
+- conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.8.6-py39h446a924_1.conda
+  noarch: python
+  sha256: 951d03994ba438f6a45c7a81f5441c4215314caf42aad02a0ff14851d9977a28
+  md5: 0caaf02db5870f138f58a81ca3b81fc1
+  depends:
+  - python
+  - tomli >=1.1.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - openssl >=3.5.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
+  size: 8084055
+  timestamp: 1747665543479
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
+  md5: 47e340acb35de30501a76c7c799c41d7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 891641
+  timestamp: 1738195959188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.1-py312h33ff503_0.conda
+  sha256: 2941c4a5fee88fe1c91c0d95b65e3a292d078f6655b53ff60f4813a44349c83e
+  md5: 3b7525d598ec0d0365ebd2378160a02f
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libcblas >=3.9.0,<4.0a0
+  - python_abi 3.12.* *_cp312
+  - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 8929128
+  timestamp: 1783206200235
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+  sha256: b4491077c494dbf0b5eaa6d87738c22f2154e9277e5293175ec187634bd808a0
+  md5: de356753cfdbffcde5bb1e86e3aa6cd0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3117410
+  timestamp: 1746223723843
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py312h8ecdadd_0.conda
+  sha256: 009408dcfdc789b8a1748d6a63fd2134ea2edc8474231ea7beba0ac3ad772a37
+  md5: 15c437bfa4cbddd379b95357c9aa4150
+  depends:
+  - python
+  - numpy >=1.26.0
+  - python-dateutil >=2.8.2
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  constrains:
+  - adbc-driver-postgresql >=1.2.0
+  - adbc-driver-sqlite >=1.2.0
+  - beautifulsoup4 >=4.12.3
+  - blosc >=1.21.3
+  - bottleneck >=1.4.2
+  - fastparquet >=2024.11.0
+  - fsspec >=2024.10.0
+  - gcsfs >=2024.10.0
+  - html5lib >=1.1
+  - hypothesis >=6.116.0
+  - jinja2 >=3.1.5
+  - lxml >=5.3.0
+  - matplotlib >=3.9.3
+  - numba >=0.60.0
+  - numexpr >=2.10.2
+  - odfpy >=1.4.1
+  - openpyxl >=3.1.5
+  - psycopg2 >=2.9.10
+  - pyarrow >=13.0.0
+  - pyiceberg >=0.8.1
+  - pymysql >=1.1.1
+  - pyqt5 >=5.15.9
+  - pyreadstat >=1.2.8
+  - pytables >=3.10.1
+  - pytest >=8.3.4
+  - pytest-xdist >=3.6.1
+  - python-calamine >=0.3.0
+  - pytz >=2024.2
+  - pyxlsb >=1.0.10
+  - qtpy >=2.4.2
+  - scipy >=1.14.1
+  - s3fs >=2024.10.0
+  - sqlalchemy >=2.0.36
+  - tabulate >=0.9.0
+  - xarray >=2024.10.0
+  - xlrd >=2.0.1
+  - xlsxwriter >=3.2.0
+  - zstandard >=0.23.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 14872605
+  timestamp: 1778602625175
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
+  sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
+  md5: 7f97faab5bebcc2580f4f299285323da
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.0,<2.1.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 32123473
+  timestamp: 1696324522323
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+  sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
+  md5: 283b96675859b20a825f8fa30f311446
+  depends:
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 282480
+  timestamp: 1740379431762
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py312h192e038_0.conda
+  sha256: 4a190c74b5f3b441820a3142b03a489987c724b65237882ebe87d75892345d17
+  md5: 40984fba15f43a366ea4c6dea2b4c8bd
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 300259
+  timestamp: 1782831325201
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.13-py312h1d08497_0.conda
+  sha256: 25e99382bbe8431e25f086960ba34de8d975c903a4810fbf2009e95285e4d719
+  md5: 8e7c909d4f48865c8c5241d83649fc66
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruff?source=hash-mapping
+  size: 8254968
+  timestamp: 1749215957598
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
+  md5: a0116df4f4ed05c303811a837d5b39d8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3285204
+  timestamp: 1748387766691
+- conda: https://conda.anaconda.org/conda-forge/linux-64/vl-convert-python-2.0.0rc1-py312h03c3619_0.conda
+  sha256: e83fd5648850c4800a341e40fe2c9f347cf60779d34fc08f0dc5b430fe4f238c
+  md5: 630e5459754c2674deb3f0dd0e4da339
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=15
+  - libsqlite >=3.51.2,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 29605757
+  timestamp: 1771114896794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_1.conda
+  sha256: 178b04c2f35261a1f9a272901d2533c88d50416745509450ca56f7bc76f4a268
+  md5: 46600bb863ef3f2f565e7e0458f3d3bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_1
+  - liblzma-devel 5.8.1 hb9d3cd8_1
+  - xz-gpl-tools 5.8.1 hbcc6ac9_1
+  - xz-tools 5.8.1 hb9d3cd8_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
+  size: 23933
+  timestamp: 1746531531849
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_1.conda
+  sha256: 1f66e240fd37f66dfaff27f55f0e69008c4fdbbb02766cd2e0a60d2de85d49b4
+  md5: 23d49402c43d1ea67aca3685acedc0ae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_1
+  constrains:
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
+  size: 33852
+  timestamp: 1746531515485
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_1.conda
+  sha256: d219c162f2bf0bb851bfe4fbcb70f118b4f518e0e1c46ae72726bc5b9dde6f24
+  md5: 966d5f3958ecfaf49a9a060dfb81eb85
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - liblzma 5.8.1 hb9d3cd8_1
+  constrains:
+  - xz 5.8.1.*
+  - xz ==5.8.1=*_1
+  license: 0BSD AND LGPL-2.1-or-later
+  purls: []
+  size: 96134
+  timestamp: 1746531500507
+- conda: https://conda.anaconda.org/conda-forge/noarch/altair-6.2.2-pyhd8ed1ab_0.conda
+  sha256: 7198ddcd5f46fdd56fd6848a336cf805744a43c2b71dee8f698151cd7947fb10
+  md5: b355b113d568e5590bbb1627ed221271
+  depends:
+  - importlib-metadata
+  - jinja2
+  - jsonschema >=3.0
+  - narwhals >=2.4.0
+  - packaging
+  - python >=3.10
+  - typing-extensions >=4.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 567614
+  timestamp: 1782378427857
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+  sha256: 1b6124230bb4e571b1b9401537ecff575b7b109cc3a21ee019f65e083b8399ab
+  md5: c6b0543676ecb1fb2d7643941fe375f2
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 64927
+  timestamp: 1773935801332
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
   sha256: 2a70ed95ace8a3f8a29e6cd1476a943df294a7111dfb3e152e3478c4c889b7ac
   md5: 95db94f75ba080a22eb623590993167b
@@ -208,46 +840,6 @@ packages:
   - pkg:pypi/colorama?source=hash-mapping
   size: 27011
   timestamp: 1733218222191
-- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.9.0-py312h178313f_0.conda
-  sha256: e490a0972f4b0740fa5d065532062e322d101de54f762d131651cbf3dd170ece
-  md5: f9527a9f8b6015f847cbf0a2be9b6a28
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - tomli
-  license: Apache-2.0
-  purls:
-  - pkg:pypi/coverage?source=hash-mapping
-  size: 373132
-  timestamp: 1749691837365
-- conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.9.2-py312h3520af0_0.conda
-  sha256: 5701b6a96a82d368f4fb7dbdb81a23c12deeb3d9c7c9af4287661de427b95776
-  md5: cff69f4e178c2a18f45487bb8756570b
-  depends:
-  - __osx >=10.13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - tomli
-  license: Apache-2.0
-  license_family: APACHE
-  size: 371093
-  timestamp: 1751548869105
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.9.0-py312h998013c_0.conda
-  sha256: 735a22fa26d05625b899ba442dafb555621c2f2e797ccbdbf1e3263682da28d4
-  md5: 6ced778bfaa9145fb930f5e605487a8f
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - tomli
-  license: Apache-2.0
-  purls:
-  - pkg:pypi/coverage?source=hash-mapping
-  size: 372011
-  timestamp: 1749691880008
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
   sha256: ce61f4f99401a4bd455b89909153b40b9c823276aefcbb06f2044618696009ca
   md5: 72e42d28960d875c7654614f8b50939a
@@ -268,6 +860,18 @@ packages:
   license_family: MIT
   size: 38835
   timestamp: 1733231086305
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+  sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
+  md5: ffc17e785d64e12fc311af9184221839
+  depends:
+  - python >=3.10
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 34766
+  timestamp: 1779714582554
 - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
   sha256: 0ec8f4d02053cd03b0f3e63168316530949484f80e16f5e2fb199a1d117a89ca
   md5: 6837f3eff7dcea42ecd714ce1ac2b108
@@ -279,393 +883,55 @@ packages:
   - pkg:pypi/iniconfig?source=hash-mapping
   size: 11474
   timestamp: 1733223232820
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
-  sha256: db73f38155d901a610b2320525b9dd3b31e4949215c870685fd92ea61b5ce472
-  md5: 01f8d123c96816249efd255a31ad7712
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+  sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
+  md5: 04558c96691bed63104678757beb4f8d
   depends:
-  - __glibc >=2.17,<3.0.a0
-  constrains:
-  - binutils_impl_linux-64 2.43
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 671240
-  timestamp: 1740155456116
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
-  sha256: b74ec832ec05571f8747c9bd5f96b93d76489909b4f6f37d99d576dc955f21e9
-  md5: 95c1830841844ef54e07efed1654b47f
-  depends:
-  - __osx >=11.0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 567539
-  timestamp: 1748495055530
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
-  sha256: 33ab03438aee65d6aa667cf7d90c91e5e7d734c19a67aa4c7040742c0a13d505
-  md5: db0bfbe7dd197b68ad5f30333bae6ce0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - expat 2.7.0.*
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 74427
-  timestamp: 1743431794976
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.0-h240833e_0.conda
-  sha256: 976f2e23ad2bb2b8e92c99bfa2ead3ad557b17a129b170f7e2dfcf233193dd7e
-  md5: 026d0a1056ba2a3dbbea6d4b08188676
-  depends:
-  - __osx >=10.13
-  constrains:
-  - expat 2.7.0.*
-  license: MIT
-  license_family: MIT
-  size: 71894
-  timestamp: 1743431912423
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
-  sha256: ee550e44765a7bbcb2a0216c063dcd53ac914a7be5386dd0554bd06e6be61840
-  md5: 6934bbb74380e045741eb8637641a65b
-  depends:
-  - __osx >=11.0
-  constrains:
-  - expat 2.7.0.*
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 65714
-  timestamp: 1743431789879
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
-  sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
-  md5: ede4673863426c0883c0063d853bbd85
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 57433
-  timestamp: 1743434498161
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
-  sha256: 6394b1bc67c64a21a5cc73d1736d1d4193a64515152e861785c44d2cfc49edf3
-  md5: 4ca9ea59839a9ca8df84170fab4ceb41
-  depends:
-  - __osx >=10.13
-  license: MIT
-  license_family: MIT
-  size: 51216
-  timestamp: 1743434595269
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-  sha256: c6a530924a9b14e193ea9adfe92843de2a806d1b7dbfd341546ece9653129e60
-  md5: c215a60c2935b517dcda8cad4705734d
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 39839
-  timestamp: 1743434670405
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
-  sha256: 0024f9ab34c09629621aefd8603ef77bf9d708129b0dd79029e502c39ffc2195
-  md5: ea8ac52380885ed41c1baa8f1d6d2b93
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==15.1.0=*_2
-  - libgomp 15.1.0 h767d61c_2
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 829108
-  timestamp: 1746642191935
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
-  sha256: 0ab5421a89f090f3aa33841036bb3af4ed85e1f91315b528a9d75fab9aad51ae
-  md5: ddca86c7040dd0e73b2b69bd7833d225
-  depends:
-  - libgcc 15.1.0 h767d61c_2
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 34586
-  timestamp: 1746642200749
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
-  sha256: 05fff3dc7e80579bc28de13b511baec281c4343d703c406aefd54389959154fb
-  md5: fbe7d535ff9d3a168c148e07358cd5b1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 452635
-  timestamp: 1746642113092
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
-  sha256: eeff241bddc8f1b87567dd6507c9f441f7f472c27f0860a07628260c000ef27c
-  md5: a76fd702c93cd2dfd89eff30a5fd45a8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - xz 5.8.1.*
-  - xz ==5.8.1=*_1
-  license: 0BSD
-  purls: []
-  size: 112845
-  timestamp: 1746531470399
-- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
-  sha256: 7e22fd1bdb8bf4c2be93de2d4e718db5c548aa082af47a7430eb23192de6bb36
-  md5: 8468beea04b9065b9807fc8b9cdc5894
-  depends:
-  - __osx >=10.13
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD
-  size: 104826
-  timestamp: 1749230155443
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
-  sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
-  md5: d6df911d4564d77c4374b02552cb17d1
-  depends:
-  - __osx >=11.0
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD
-  purls: []
-  size: 92286
-  timestamp: 1749230283517
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_1.conda
-  sha256: f157a2da5f7bf2c5ce5a18c52ccc76c39f075f7fbb1584d585a8d25c1b17cb92
-  md5: 5499e2dd2f567a818b9f111e47caebd2
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - liblzma 5.8.1 hb9d3cd8_1
-  license: 0BSD
-  purls: []
-  size: 441592
-  timestamp: 1746531484594
-- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.8.1-hd471939_2.conda
-  sha256: a020ad9f1e27d4f7a522cbbb9613b99f64a5cc41f80caf62b9fdd1cf818acf18
-  md5: 2e16f5b4f6c92b96f6a346f98adc4e3e
-  depends:
-  - __osx >=10.13
-  - liblzma 5.8.1 hd471939_2
-  license: 0BSD
-  size: 116356
-  timestamp: 1749230171181
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
-  sha256: 974804430e24f0b00f3a48b67ec10c9f5441c9bb3d82cc0af51ba45b8a75a241
-  md5: 1201137f1a5ec9556032ffc04dcdde8d
-  depends:
-  - __osx >=11.0
-  - liblzma 5.8.1 h39f12f2_2
-  license: 0BSD
-  purls: []
-  size: 116244
-  timestamp: 1749230297170
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
-  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  license_family: GPL
-  purls: []
-  size: 33408
-  timestamp: 1697359010159
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.49.2-hee588c1_0.conda
-  sha256: 525d4a0e24843f90b3ff1ed733f0a2e408aa6dd18b9d4f15465595e078e104a2
-  md5: 93048463501053a00739215ea3f36324
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  purls: []
-  size: 916313
-  timestamp: 1746637007836
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.2-he7d56d0_0.conda
-  sha256: bd3ab15e14d7e88851c962034d97519a135d86f79f88b3237fbfb34194c114cb
-  md5: 678284738efc450afcf90f70365f7318
-  depends:
-  - __osx >=10.13
-  - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  size: 980106
-  timestamp: 1751135725501
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.1-h3f77e49_0.conda
-  sha256: f39e22a00396c048dcfcb5d8c9dbedb2d69f06edcd8dba98b87f263eeb6d2049
-  md5: 73df23998b27dd6774d03db626d031d3
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  purls: []
-  size: 901258
-  timestamp: 1749232800279
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
-  sha256: 6ae3d153e78f6069d503d9309f2cac6de5b93d067fc6433160a4c05226a5dad4
-  md5: 1cb1c67961f6dd257eae9e9691b341aa
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc 15.1.0 h767d61c_2
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 3902355
-  timestamp: 1746642227493
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
-  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
-  depends:
-  - libgcc-ng >=12
+  - markupsafe >=2.0
+  - python >=3.10
+  - python
   license: BSD-3-Clause
   license_family: BSD
-  purls: []
-  size: 33601
-  timestamp: 1680112270483
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  run_exports: {}
+  size: 120685
+  timestamp: 1764517220861
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+  sha256: db973a37d75db8e19b5f44bbbdaead0c68dde745407f281e2a7fe4db74ec51d7
+  md5: ada41c863af263cc4c5fcbaff7c3e4dc
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 60963
-  timestamp: 1727963148474
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
-  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
-  md5: 003a54a4e32b02f7355b50a837e699da
-  depends:
-  - __osx >=10.13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  size: 57133
-  timestamp: 1727963183990
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
-  md5: 369964e85dc26bfe78f41399b366c435
-  depends:
-  - __osx >=11.0
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 46438
-  timestamp: 1727963202283
-- conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.8.6-py39h446a924_1.conda
-  noarch: python
-  sha256: 951d03994ba438f6a45c7a81f5441c4215314caf42aad02a0ff14851d9977a28
-  md5: 0caaf02db5870f138f58a81ca3b81fc1
-  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.3.6
+  - python >=3.10
+  - referencing >=0.28.4
+  - rpds-py >=0.25.0
   - python
-  - tomli >=1.1.0
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - openssl >=3.5.0,<4.0a0
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/maturin?source=hash-mapping
-  size: 8084055
-  timestamp: 1747665543479
-- conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.8.6-py39h21b1788_1.conda
-  noarch: python
-  sha256: f8a4169a27e105165dab48f712d20ce0795bd226185d4f889e055994a78c3a55
-  md5: a5f6f180671b64270ea94ecd43758790
+  run_exports: {}
+  size: 82356
+  timestamp: 1767839954256
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+  sha256: 0a4f3b132f0faca10c89fdf3b60e15abb62ded6fa80aebfc007d05965192aa04
+  md5: 439cd0f567d697b20a8f45cb70a1005a
   depends:
+  - python >=3.10
+  - referencing >=0.31.0
   - python
-  - tomli >=1.1.0
-  - __osx >=10.13
-  - openssl >=3.5.0,<4.0a0
   license: MIT
   license_family: MIT
-  size: 6716541
-  timestamp: 1747665647962
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.8.6-py39h3b6e2d1_1.conda
-  noarch: python
-  sha256: 71507a4d26be4748cc0125ccfbc0a8792fd4af62002befdff41b51c354578941
-  md5: 071f0bd323e3e1a77b5432a08e2c6e80
+  run_exports: {}
+  size: 19236
+  timestamp: 1757335715225
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.24.0-pyhcf101f3_0.conda
+  sha256: 57f525a1c55b08c3204fab05d2c74a3e9c2172d7f08f1ecaa07e19865cc1d7cf
+  md5: 42ef6cbb3e1d0e6689b9dd160f560eae
   depends:
+  - python >=3.10
   - python
-  - tomli >=1.1.0
-  - __osx >=11.0
-  - openssl >=3.5.0,<4.0a0
   license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/maturin?source=hash-mapping
-  size: 6452309
-  timestamp: 1747665595137
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
-  md5: 47e340acb35de30501a76c7c799c41d7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: X11 AND BSD-3-Clause
-  purls: []
-  size: 891641
-  timestamp: 1738195959188
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
-  sha256: ea4a5d27ded18443749aefa49dc79f6356da8506d508b5296f60b8d51e0c4bd9
-  md5: ced34dd9929f491ca6dab6a2927aff25
-  depends:
-  - __osx >=10.13
-  license: X11 AND BSD-3-Clause
-  size: 822259
-  timestamp: 1738196181298
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-  sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
-  md5: 068d497125e4bf8a66bf707254fff5ae
-  depends:
-  - __osx >=11.0
-  license: X11 AND BSD-3-Clause
-  purls: []
-  size: 797030
-  timestamp: 1738196177597
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
-  sha256: b4491077c494dbf0b5eaa6d87738c22f2154e9277e5293175ec187634bd808a0
-  md5: de356753cfdbffcde5bb1e86e3aa6cd0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ca-certificates
-  - libgcc >=13
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 3117410
-  timestamp: 1746223723843
-- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.1-hc426f3f_0.conda
-  sha256: d5dc7da2ef7502a14f88443675c4894db336592ac7b9ae0517e1339ebb94f38a
-  md5: f1ac2dbc36ce2017bd8f471960b1261d
-  depends:
-  - __osx >=10.13
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 2744123
-  timestamp: 1751391059798
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
-  sha256: 73d366c1597a10bcd5f3604b5f0734b31c23225536e03782c6a13f9be9d01bff
-  md5: 5c7aef00ef60738a14e0e612cfc5bcde
-  depends:
-  - __osx >=11.0
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 3064197
-  timestamp: 1746223530698
+  run_exports: {}
+  size: 289946
+  timestamp: 1783943716915
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
   sha256: 289861ed0c13a15d7bbb408796af4de72c2fe67e2bcb0de98f4c3fce259d7991
   md5: 58335b26c38bf4a20f399384c33cbcf9
@@ -829,72 +1095,18 @@ packages:
   license_family: MIT
   size: 39300
   timestamp: 1751452761594
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
-  sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
-  md5: 7f97faab5bebcc2580f4f299285323da
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+  md5: 5b8d21249ff20967101ffa321cab24e8
   depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libnsl >=2.0.0,<2.1.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.3,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 32123473
-  timestamp: 1696324522323
-- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.0-h30d4d87_0_cpython.conda
-  sha256: 0a1ed3983acbd0528bef5216179e46170f024f4409032875b27865568fef46a1
-  md5: d11dc8f4551011fb6baa2865f1ead48f
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.3,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  size: 14529683
-  timestamp: 1696323482650
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
-  sha256: eb66f8f249caa9d5a956c3a407f079e4779d652ebfc2a4b4f50dcea078e84fa8
-  md5: ed8ae98b1b510de68392971b9367d18c
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.3,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 13306758
-  timestamp: 1696322682581
+  - python >=3.9
+  - six >=1.5
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 233310
+  timestamp: 1751104122689
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-7_cp312.conda
   build_number: 7
   sha256: a1bbced35e0df66cc713105344263570e835625c28d1bdee8f748f482b2d7793
@@ -906,83 +1118,20 @@ packages:
   purls: []
   size: 6971
   timestamp: 1745258861359
-- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-  sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
-  md5: 283b96675859b20a825f8fa30f311446
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+  sha256: 0577eedfb347ff94d0f2fa6c052c502989b028216996b45c7f21236f25864414
+  md5: 870293df500ca7e18bedefa5838a22ab
   depends:
-  - libgcc >=13
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 282480
-  timestamp: 1740379431762
-- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
-  sha256: 53017e80453c4c1d97aaf78369040418dea14cf8f46a2fa999f31bd70b36c877
-  md5: 342570f8e02f2f022147a7f841475784
-  depends:
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 256712
-  timestamp: 1740379577668
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
-  sha256: 7db04684d3904f6151eff8673270922d31da1eea7fa73254d01c437f49702e34
-  md5: 63ef3f6e6d6d5c589e64f11263dc5676
-  depends:
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 252359
-  timestamp: 1740379663071
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.13-py312h1d08497_0.conda
-  sha256: 25e99382bbe8431e25f086960ba34de8d975c903a4810fbf2009e95285e4d719
-  md5: 8e7c909d4f48865c8c5241d83649fc66
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruff?source=hash-mapping
-  size: 8254968
-  timestamp: 1749215957598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.12.2-h8aa17f0_0.conda
-  noarch: python
-  sha256: 4a568883b41b52304b9e4e34ab7e6567f02b673f4cbdab8f5971e1d59ceb8c75
-  md5: ed1e6a190c90402d1836082eec62b2df
-  depends:
+  - attrs >=22.2.0
+  - python >=3.10
+  - rpds-py >=0.7.0
+  - typing_extensions >=4.4.0
   - python
-  - __osx >=10.13
-  constrains:
-  - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 9308040
-  timestamp: 1751584723872
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.11.13-py312h846f395_0.conda
-  sha256: e61d21b1cce7dd07436937bce9e98f832ca08e1fc10c9e676eb7352d703b865c
-  md5: 183fd50b1c0b9c37490d044e151013f3
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruff?source=hash-mapping
-  size: 7451777
-  timestamp: 1749216226429
+  run_exports: {}
+  size: 51788
+  timestamp: 1760379115194
 - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
   sha256: 972560fcf9657058e3e1f97186cc94389144b46dbdf58c807ce62e83f977e863
   md5: 4de79c071274a53dcaf2a8c749d1499e
@@ -992,39 +1141,17 @@ packages:
   license_family: MIT
   size: 748788
   timestamp: 1748804951958
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
-  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
-  md5: a0116df4f4ed05c303811a837d5b39d8
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+  sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
+  md5: 3339e3b65d58accf4ca4fb8748ab16b3
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: TCL
-  license_family: BSD
-  purls: []
-  size: 3285204
-  timestamp: 1748387766691
-- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
-  sha256: b24468006a96b71a5f4372205ea7ec4b399b0f2a543541e86f883de54cd623fc
-  md5: 9864891a6946c2fe037c02fca7392ab4
-  depends:
-  - __osx >=10.13
-  - libzlib >=1.3.1,<2.0a0
-  license: TCL
-  license_family: BSD
-  size: 3259809
-  timestamp: 1748387843735
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
-  sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
-  md5: 7362396c170252e7b7b0c8fb37fe9c78
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: TCL
-  license_family: BSD
-  purls: []
-  size: 3125538
-  timestamp: 1748388189063
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 18455
+  timestamp: 1753199211006
 - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
   sha256: 34f3a83384ac3ac30aefd1309e69498d8a4aa0bf2d1f21c645f79b180e378938
   md5: b0dd904de08b7db706167240bf37b164
@@ -1047,39 +1174,27 @@ packages:
   - pkg:pypi/tomli?source=hash-mapping
   size: 19167
   timestamp: 1733256819729
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.13.2-pyh29332c3_0.conda
-  sha256: a8aaf351e6461de0d5d47e4911257e25eec2fa409d71f3b643bb2f748bde1c08
-  md5: 83fc6ae00127671e301c9f44254c31b8
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+  sha256: b141933ece3518f6d7b75dfb59451e2f26b405a44c18e2518a83e9a02e09315c
+  md5: c680b5747e8c4c8f23dca0bb7042a8fc
   depends:
-  - python >=3.9
+  - typing_extensions ==4.16.0 pyhcf101f3_0
+  license: PSF-2.0
+  license_family: PSF
+  run_exports: {}
+  size: 94080
+  timestamp: 1783002732887
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+  sha256: 2d888f90af0686044882c74193ec80a90ec1943145d94a7b1b048958acda1848
+  md5: c70ad746c22219b9700931707482992c
+  depends:
+  - python >=3.10
   - python
   license: PSF-2.0
   license_family: PSF
-  purls:
-  - pkg:pypi/typing-extensions?source=compressed-mapping
-  size: 52189
-  timestamp: 1744302253997
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.0-pyhe01879c_0.conda
-  sha256: 8561db52f278c5716b436da6d4ee5521712a49e8f3c70fcae5350f5ebb4be41c
-  md5: 2adcd9bb86f656d3d43bf84af59a1faf
-  depends:
-  - python >=3.9
-  - python
-  license: PSF-2.0
-  license_family: PSF
-  purls:
-  - pkg:pypi/typing-extensions?source=compressed-mapping
-  size: 50978
-  timestamp: 1748959427551
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.1-pyhe01879c_0.conda
-  sha256: 4f52390e331ea8b9019b87effaebc4f80c6466d09f68453f52d5cdc2a3e1194f
-  md5: e523f4f1e980ed7a4240d7e27e9ec81f
-  depends:
-  - python >=3.9
-  - python
-  license: PSF-2.0
-  size: 51065
-  timestamp: 1751643513473
+  run_exports: {}
+  size: 52631
+  timestamp: 1783002732887
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
   sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
   md5: 4222072737ccff51314b5ece9c7d6f5a
@@ -1096,20 +1211,463 @@ packages:
   license_family: MIT
   size: 62931
   timestamp: 1733130309598
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_1.conda
-  sha256: 178b04c2f35261a1f9a272901d2533c88d50416745509450ca56f7bc76f4a268
-  md5: 46600bb863ef3f2f565e7e0458f3d3bc
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+  sha256: 210bd31c22bb88f5e2a167df24c95bb5f152b2ada7502f9b8c49d1f5366db423
+  md5: ba3dcdc8584155c97c648ae9c044b7a3
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - liblzma 5.8.1 hb9d3cd8_1
-  - liblzma-devel 5.8.1 hb9d3cd8_1
-  - xz-gpl-tools 5.8.1 hbcc6ac9_1
-  - xz-tools 5.8.1 hb9d3cd8_1
-  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
-  purls: []
-  size: 23933
-  timestamp: 1746531531849
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 24190
+  timestamp: 1779159948016
+- conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  build_number: 7
+  sha256: 30006902a9274de8abdad5a9f02ef7c8bb3d69a503486af0c1faee30b023e5b7
+  md5: eaac87c21aff3ed21ad9656697bb8326
+  depends:
+  - llvm-openmp >=9.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - _openmp_mutex >=4.5
+  size: 8328
+  timestamp: 1764092562779
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 134188
+  timestamp: 1720974491916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.9.2-py312h3520af0_0.conda
+  sha256: 5701b6a96a82d368f4fb7dbdb81a23c12deeb3d9c7c9af4287661de427b95776
+  md5: cff69f4e178c2a18f45487bb8756570b
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  size: 371093
+  timestamp: 1751548869105
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+  sha256: 1294117122d55246bb83ad5b589e2a031aacdf2d0b1f99fd338aa4394f881735
+  md5: 627eca44e62e2b665eeec57a984a7f00
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 12273764
+  timestamp: 1773822733780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-8_he492b99_openblas.conda
+  build_number: 8
+  sha256: 55cf9f92a2d07c33f8a32c44ff1528ea48fd69677cc003a4532d09b71cb8a316
+  md5: 7da1e8ab7c4498db9457c191d82930a3
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - mkl <2027
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  - libcblas   3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 19048
+  timestamp: 1779860008916
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-8_h9b27e0a_openblas.conda
+  build_number: 8
+  sha256: 50eb650a17a34ea45fe2b31e60a98632d1f8c203308014dcef93043d54612482
+  md5: 4f116127b172bbba835c1e0491efd86f
+  depends:
+  - libblas 3.11.0 8_he492b99_openblas
+  constrains:
+  - liblapacke 3.11.0   8*_openblas
+  - blas 2.308   openblas
+  - liblapack  3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 19049
+  timestamp: 1779860025163
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
+  sha256: 57ee997f1f800cf38abc743c0f0a9ddfe6a101c697c35510452ce6f4ddf96361
+  md5: 0f600157f28fc7bc9549ecafdfa5bc12
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 566717
+  timestamp: 1781672189697
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.0-h240833e_0.conda
+  sha256: 976f2e23ad2bb2b8e92c99bfa2ead3ad557b17a129b170f7e2dfcf233193dd7e
+  md5: 026d0a1056ba2a3dbbea6d4b08188676
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.7.0.*
+  license: MIT
+  license_family: MIT
+  size: 71894
+  timestamp: 1743431912423
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+  sha256: 6394b1bc67c64a21a5cc73d1736d1d4193a64515152e861785c44d2cfc49edf3
+  md5: 4ca9ea59839a9ca8df84170fab4ceb41
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 51216
+  timestamp: 1743434595269
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
+  sha256: 17a5dcd818f89173db51d7d1acd77615cb77db7b4c2b5f571d4dafe559430ab5
+  md5: 4bf33d5ca73f4b89d3495285a42414a4
+  depends:
+  - _openmp_mutex
+  constrains:
+  - libgomp 15.2.0 19
+  - libgcc-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 424164
+  timestamp: 1778271183296
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
+  sha256: 519045363b87b870be779d38f0bfd325d4b787acdaa0a2136a92c1081eff5112
+  md5: d362f41203d0a1d2d4940446f95374c9
+  depends:
+  - libgfortran5 15.2.0 hd16e46c_19
+  constrains:
+  - libgfortran-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 139925
+  timestamp: 1778271458366
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
+  sha256: c7f5f6e80357d6d5bc69588c16144205b0c79cf32cd090ccb5afef9d557632af
+  md5: 1cddb3f7e54f5871297afc0fafa61c2c
+  depends:
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 1063687
+  timestamp: 1778271196574
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-8_h859234e_openblas.conda
+  build_number: 8
+  sha256: 56a68fce5a63d4583a42c212324d62ac292376b8bf05986a551bd640e7fa137d
+  md5: e11ee849bd2a573a0f6e53b1b67ebf37
+  depends:
+  - libblas 3.11.0 8_he492b99_openblas
+  constrains:
+  - liblapacke 3.11.0   8*_openblas
+  - libcblas   3.11.0   8*_openblas
+  - blas 2.308   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 19030
+  timestamp: 1779860046842
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
+  sha256: 7e22fd1bdb8bf4c2be93de2d4e718db5c548aa082af47a7430eb23192de6bb36
+  md5: 8468beea04b9065b9807fc8b9cdc5894
+  depends:
+  - __osx >=10.13
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  size: 104826
+  timestamp: 1749230155443
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.8.1-hd471939_2.conda
+  sha256: a020ad9f1e27d4f7a522cbbb9613b99f64a5cc41f80caf62b9fdd1cf818acf18
+  md5: 2e16f5b4f6c92b96f6a346f98adc4e3e
+  depends:
+  - __osx >=10.13
+  - liblzma 5.8.1 hd471939_2
+  license: 0BSD
+  size: 116356
+  timestamp: 1749230171181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.33-openmp_h9e49c7b_0.conda
+  sha256: 2c2ffe7c3ab7becd47ad308946873d2bdc219625af32a53d10efbaa54b595d31
+  md5: 30666a6f0afe1471e999eca7ae5c8179
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.33,<0.3.34.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libopenblas >=0.3.33,<1.0a0
+  size: 6287889
+  timestamp: 1776996499823
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.3-h8f8c405_0.conda
+  sha256: 84d4af77021ca28e02ff60f396575b921ed1747e459838daa0e73b4724b47953
+  md5: 72d9eaef59342a3614c83d57a32f578b
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  run_exports:
+    weak:
+    - libsqlite >=3.53.3,<4.0a0
+  size: 1012648
+  timestamp: 1782519619230
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+  sha256: 4c6da089952b2d70150c74234679d6f7ac04f4a98f9432dec724968f912691e7
+  md5: 30439ff30578e504ee5e0b390afc8c65
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 59000
+  timestamp: 1774073052242
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
+  sha256: 7e8dcf03c2ef5491405d6d86eb892d14e99902f50f4eeb250db0cbdc58dd5818
+  md5: 9d5828c46147a47f828ca47a18407621
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 22.1.8|22.1.8.*
+  - intel-openmp <0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    strong:
+    - llvm-openmp >=22.1.8
+  size: 311645
+  timestamp: 1781737360942
+- conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py312heb39f77_1.conda
+  sha256: 0eb418d4776a1a54c1869b11a5c4ae096ef9a46c8d7e481e32fa814561c5cfed
+  md5: d596f9d03043acd4ec711c844060da59
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 25095
+  timestamp: 1772445399364
+- conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.8.6-py39h21b1788_1.conda
+  noarch: python
+  sha256: f8a4169a27e105165dab48f712d20ce0795bd226185d4f889e055994a78c3a55
+  md5: a5f6f180671b64270ea94ecd43758790
+  depends:
+  - python
+  - tomli >=1.1.0
+  - __osx >=10.13
+  - openssl >=3.5.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 6716541
+  timestamp: 1747665647962
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+  sha256: ea4a5d27ded18443749aefa49dc79f6356da8506d508b5296f60b8d51e0c4bd9
+  md5: ced34dd9929f491ca6dab6a2927aff25
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822259
+  timestamp: 1738196181298
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.5.1-py312h746d82c_0.conda
+  sha256: e98ee4e0e15ee5ee8c82b9580de1d99a3e22a2d2f612a0573e6a8e4fc430a129
+  md5: 34950d8877f08ad0a89ba0d603fcdf1f
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - python_abi 3.12.* *_cp312
+  - liblapack >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 8125715
+  timestamp: 1783206312597
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.1-hc426f3f_0.conda
+  sha256: d5dc7da2ef7502a14f88443675c4894db336592ac7b9ae0517e1339ebb94f38a
+  md5: f1ac2dbc36ce2017bd8f471960b1261d
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2744123
+  timestamp: 1751391059798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.3-py312h8e27051_0.conda
+  sha256: d72b541b510e3a1db86db3ce8d4c30bddc945c3c89eb2c9d16fde0cc9f82e497
+  md5: 8cfffbf760a7d7abc16c79141ead177a
+  depends:
+  - python
+  - numpy >=1.26.0
+  - python-dateutil >=2.8.2
+  - libcxx >=19
+  - __osx >=11.0
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - adbc-driver-postgresql >=1.2.0
+  - adbc-driver-sqlite >=1.2.0
+  - beautifulsoup4 >=4.12.3
+  - blosc >=1.21.3
+  - bottleneck >=1.4.2
+  - fastparquet >=2024.11.0
+  - fsspec >=2024.10.0
+  - gcsfs >=2024.10.0
+  - html5lib >=1.1
+  - hypothesis >=6.116.0
+  - jinja2 >=3.1.5
+  - lxml >=5.3.0
+  - matplotlib >=3.9.3
+  - numba >=0.60.0
+  - numexpr >=2.10.2
+  - odfpy >=1.4.1
+  - openpyxl >=3.1.5
+  - psycopg2 >=2.9.10
+  - pyarrow >=13.0.0
+  - pyiceberg >=0.8.1
+  - pymysql >=1.1.1
+  - pyqt5 >=5.15.9
+  - pyreadstat >=1.2.8
+  - pytables >=3.10.1
+  - pytest >=8.3.4
+  - pytest-xdist >=3.6.1
+  - python-calamine >=0.3.0
+  - pytz >=2024.2
+  - pyxlsb >=1.0.10
+  - qtpy >=2.4.2
+  - scipy >=1.14.1
+  - s3fs >=2024.10.0
+  - sqlalchemy >=2.0.36
+  - tabulate >=0.9.0
+  - xarray >=2024.10.0
+  - xlrd >=2.0.1
+  - xlsxwriter >=3.2.0
+  - zstandard >=0.23.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 14170082
+  timestamp: 1778602746933
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.0-h30d4d87_0_cpython.conda
+  sha256: 0a1ed3983acbd0528bef5216179e46170f024f4409032875b27865568fef46a1
+  md5: d11dc8f4551011fb6baa2865f1ead48f
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  size: 14529683
+  timestamp: 1696323482650
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+  sha256: 53017e80453c4c1d97aaf78369040418dea14cf8f46a2fa999f31bd70b36c877
+  md5: 342570f8e02f2f022147a7f841475784
+  depends:
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 256712
+  timestamp: 1740379577668
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-2026.6.3-py312hb77ea7e_0.conda
+  sha256: fa9073cd4c1fcfad1cfa5801ee3a6176de19eff2ecf43abfea0e415c475d34a8
+  md5: 2832076dd06bd57d1895b230bb7e1b95
+  depends:
+  - python
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 301356
+  timestamp: 1782831427136
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.12.2-h8aa17f0_0.conda
+  noarch: python
+  sha256: 4a568883b41b52304b9e4e34ab7e6567f02b673f4cbdab8f5971e1d59ceb8c75
+  md5: ed1e6a190c90402d1836082eec62b2df
+  depends:
+  - python
+  - __osx >=10.13
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 9308040
+  timestamp: 1751584723872
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+  sha256: b24468006a96b71a5f4372205ea7ec4b399b0f2a543541e86f883de54cd623fc
+  md5: 9864891a6946c2fe037c02fca7392ab4
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3259809
+  timestamp: 1748387843735
+- conda: https://conda.anaconda.org/conda-forge/osx-64/vl-convert-python-2.0.0rc1-py312h03bf33c_0.conda
+  sha256: d4a3139f919f1ecd4079864517f72146408a83e97535a264ee1e82e1a1902f7b
+  md5: f1cf379ae0b3d99b05dd8100ab1892f3
+  depends:
+  - __osx >=11.0
+  - libsqlite >=3.51.2,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=10.13
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 26960667
+  timestamp: 1771115146411
 - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.8.1-h357f2ed_2.conda
   sha256: 89248de6c9417522b6fec011dc26b81c25af731a31ba91e668f72f1b9aab05d7
   md5: 7eee908c7df8478c1f35b28efa2e42b1
@@ -1122,6 +1680,477 @@ packages:
   license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
   size: 24033
   timestamp: 1749230223096
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-gpl-tools-5.8.1-h357f2ed_2.conda
+  sha256: 5cdadfff31de7f50d1b2f919dd80697c0a08d90f8d6fb89f00c93751ec135c3c
+  md5: d4044359fad6af47224e9ef483118378
+  depends:
+  - __osx >=10.13
+  - liblzma 5.8.1 hd471939_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  size: 33890
+  timestamp: 1749230206830
+- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.8.1-hd471939_2.conda
+  sha256: 3b1d8958f8dceaa4442100d5326b2ec9bcc2e8d7ee55345bf7101dc362fb9868
+  md5: 349148960ad74aece88028f2b5c62c51
+  depends:
+  - __osx >=10.13
+  - liblzma 5.8.1 hd471939_2
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD AND LGPL-2.1-or-later
+  size: 85777
+  timestamp: 1749230191007
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  build_number: 7
+  sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
+  md5: a44032f282e7d2acdeb1c240308052dd
+  depends:
+  - llvm-openmp >=9.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - _openmp_mutex >=4.5
+  size: 8325
+  timestamp: 1764092507920
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.9.0-py312h998013c_0.conda
+  sha256: 735a22fa26d05625b899ba442dafb555621c2f2e797ccbdbf1e3263682da28d4
+  md5: 6ced778bfaa9145fb930f5e605487a8f
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - tomli
+  license: Apache-2.0
+  purls:
+  - pkg:pypi/coverage?source=hash-mapping
+  size: 372011
+  timestamp: 1749691880008
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+  build_number: 8
+  sha256: 8f5ec18ead0619a9cf0f38b49796c22f6fc0f44850c0df2baea0f5277db16e75
+  md5: dbfe729181a32741ae63ecb41eefbac6
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - blas 2.308   openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  - libcblas   3.11.0   8*_openblas
+  - mkl <2027
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 18949
+  timestamp: 1779859141315
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+  build_number: 8
+  sha256: f93efcd44bc24f97c2478c7474d3baa6801a057974f330e1d06bedc33e4c778f
+  md5: 03a2ef3491da9e5b4d18c03e9f4b3109
+  depends:
+  - libblas 3.11.0 8_h51639a9_openblas
+  constrains:
+  - blas 2.308   openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 18911
+  timestamp: 1779859147634
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
+  sha256: b74ec832ec05571f8747c9bd5f96b93d76489909b4f6f37d99d576dc955f21e9
+  md5: 95c1830841844ef54e07efed1654b47f
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 567539
+  timestamp: 1748495055530
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
+  sha256: ee550e44765a7bbcb2a0216c063dcd53ac914a7be5386dd0554bd06e6be61840
+  md5: 6934bbb74380e045741eb8637641a65b
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.7.0.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 65714
+  timestamp: 1743431789879
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+  sha256: c6a530924a9b14e193ea9adfe92843de2a806d1b7dbfd341546ece9653129e60
+  md5: c215a60c2935b517dcda8cad4705734d
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 39839
+  timestamp: 1743434670405
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+  sha256: 06644fa4d34d57c9e48f4d84b1256f9e5f654fdb37f43acc8a58a396952d42b7
+  md5: 644058123986582db33aebd4ae2ca184
+  depends:
+  - _openmp_mutex
+  constrains:
+  - libgcc-ng ==15.2.0=*_19
+  - libgomp 15.2.0 19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 404080
+  timestamp: 1778273064154
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+  sha256: d4837b3b9b30af3132d260225e91ab9dde83be04c59513f500cc81050fb37486
+  md5: 1ea03f87cdb1078fbc0e2b2deb63752c
+  depends:
+  - libgfortran5 15.2.0 hdae7583_19
+  constrains:
+  - libgfortran-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 139675
+  timestamp: 1778273280875
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+  sha256: d0a68b7a121d115b80c169e24d1265dcc25a3fe58d107df1bbc430797e226d88
+  md5: ba36d8c606a6a53fe0b8c12d47267b3d
+  depends:
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 599691
+  timestamp: 1778273075448
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+  build_number: 8
+  sha256: 8a076fe82142a00fe85f5a5a5351e286e8064f0100fe13608d19182cd0018c25
+  md5: 85adeb3d469d082dbd9c8c39e36dec57
+  depends:
+  - libblas 3.11.0 8_h51639a9_openblas
+  constrains:
+  - libcblas   3.11.0   8*_openblas
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 18925
+  timestamp: 1779859153970
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+  sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
+  md5: d6df911d4564d77c4374b02552cb17d1
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.1.*
+  license: 0BSD
+  purls: []
+  size: 92286
+  timestamp: 1749230283517
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
+  sha256: 974804430e24f0b00f3a48b67ec10c9f5441c9bb3d82cc0af51ba45b8a75a241
+  md5: 1201137f1a5ec9556032ffc04dcdde8d
+  depends:
+  - __osx >=11.0
+  - liblzma 5.8.1 h39f12f2_2
+  license: 0BSD
+  purls: []
+  size: 116244
+  timestamp: 1749230297170
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+  sha256: 9dd455b2d172aeedfa2058d324b5b5822b0bc1b7c1f32cd183d7078540d2f6eb
+  md5: 909e41855c29f0d52ae630198cd57135
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.33,<0.3.34.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libopenblas >=0.3.33,<1.0a0
+  size: 4304965
+  timestamp: 1776995497368
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.1-h3f77e49_0.conda
+  sha256: f39e22a00396c048dcfcb5d8c9dbedb2d69f06edcd8dba98b87f263eeb6d2049
+  md5: 73df23998b27dd6774d03db626d031d3
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  purls: []
+  size: 901258
+  timestamp: 1749232800279
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+  sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
+  md5: a9c118f6343fb6301b6f3b4e94c4c562
+  depends:
+  - __osx >=11.0
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 22.1.8|22.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    strong:
+    - llvm-openmp >=22.1.8
+  size: 286313
+  timestamp: 1781736516782
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py312h04c11ed_1.conda
+  sha256: 330394fb9140995b29ae215a19fad46fcc6691bdd1b7654513d55a19aaa091c1
+  md5: 11d95ab83ef0a82cc2de12c1e0b47fe4
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 25564
+  timestamp: 1772445846939
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.8.6-py39h3b6e2d1_1.conda
+  noarch: python
+  sha256: 71507a4d26be4748cc0125ccfbc0a8792fd4af62002befdff41b51c354578941
+  md5: 071f0bd323e3e1a77b5432a08e2c6e80
+  depends:
+  - python
+  - tomli >=1.1.0
+  - __osx >=11.0
+  - openssl >=3.5.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/maturin?source=hash-mapping
+  size: 6452309
+  timestamp: 1747665595137
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+  sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
+  md5: 068d497125e4bf8a66bf707254fff5ae
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 797030
+  timestamp: 1738196177597
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.1-py312ha003a3f_0.conda
+  sha256: 997182a5b36425c2d3469d4d032dd2f1445fcff5fd2ba6911f815410cfafe9b2
+  md5: 1053a4cbe2328d5c9ee86a4df5acba35
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=11.0
+  - liblapack >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 6979168
+  timestamp: 1783206218662
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
+  sha256: 73d366c1597a10bcd5f3604b5f0734b31c23225536e03782c6a13f9be9d01bff
+  md5: 5c7aef00ef60738a14e0e612cfc5bcde
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3064197
+  timestamp: 1746223530698
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.3-py312h6510ced_0.conda
+  sha256: 7202013525593f57a452dac7e5fee9f26478822be3ba5c893643517b8627406d
+  md5: 4581a32b837950217327fcab93214313
+  depends:
+  - python
+  - numpy >=1.26.0
+  - python-dateutil >=2.8.2
+  - __osx >=11.0
+  - python 3.12.* *_cpython
+  - libcxx >=19
+  - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
+  constrains:
+  - adbc-driver-postgresql >=1.2.0
+  - adbc-driver-sqlite >=1.2.0
+  - beautifulsoup4 >=4.12.3
+  - blosc >=1.21.3
+  - bottleneck >=1.4.2
+  - fastparquet >=2024.11.0
+  - fsspec >=2024.10.0
+  - gcsfs >=2024.10.0
+  - html5lib >=1.1
+  - hypothesis >=6.116.0
+  - jinja2 >=3.1.5
+  - lxml >=5.3.0
+  - matplotlib >=3.9.3
+  - numba >=0.60.0
+  - numexpr >=2.10.2
+  - odfpy >=1.4.1
+  - openpyxl >=3.1.5
+  - psycopg2 >=2.9.10
+  - pyarrow >=13.0.0
+  - pyiceberg >=0.8.1
+  - pymysql >=1.1.1
+  - pyqt5 >=5.15.9
+  - pyreadstat >=1.2.8
+  - pytables >=3.10.1
+  - pytest >=8.3.4
+  - pytest-xdist >=3.6.1
+  - python-calamine >=0.3.0
+  - pytz >=2024.2
+  - pyxlsb >=1.0.10
+  - qtpy >=2.4.2
+  - scipy >=1.14.1
+  - s3fs >=2024.10.0
+  - sqlalchemy >=2.0.36
+  - tabulate >=0.9.0
+  - xarray >=2024.10.0
+  - xlrd >=2.0.1
+  - xlsxwriter >=3.2.0
+  - zstandard >=0.23.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 13926263
+  timestamp: 1778602825408
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
+  sha256: eb66f8f249caa9d5a956c3a407f079e4779d652ebfc2a4b4f50dcea078e84fa8
+  md5: ed8ae98b1b510de68392971b9367d18c
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 13306758
+  timestamp: 1696322682581
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+  sha256: 7db04684d3904f6151eff8673270922d31da1eea7fa73254d01c437f49702e34
+  md5: 63ef3f6e6d6d5c589e64f11263dc5676
+  depends:
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 252359
+  timestamp: 1740379663071
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-2026.6.3-py312h8b1d842_0.conda
+  sha256: c9a1a6243ba1d20e4ccc6fb172259bbdfcc9bea95a2cbef8cd7f66330de35cc0
+  md5: ca4e32f2b1794e0e3ca071cc84995c4a
+  depends:
+  - python
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 286191
+  timestamp: 1782831381815
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.11.13-py312h846f395_0.conda
+  sha256: e61d21b1cce7dd07436937bce9e98f832ca08e1fc10c9e676eb7352d703b865c
+  md5: 183fd50b1c0b9c37490d044e151013f3
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ruff?source=hash-mapping
+  size: 7451777
+  timestamp: 1749216226429
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+  sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
+  md5: 7362396c170252e7b7b0c8fb37fe9c78
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3125538
+  timestamp: 1748388189063
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/vl-convert-python-2.0.0rc1-py312h2bbb03f_0.conda
+  sha256: 7b453cb1c6d1dc401275e2a80af6b7927d13b59581c2839401111f2e5ec70ea9
+  md5: da6c4a795772875d1b303822f6e1daf7
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=10.13
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 27220486
+  timestamp: 1771113860197
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
   sha256: afb747cf017b67cc31d54c6e6c4bd1b1e179fe487a3d23a856232ed7fd0b099b
   md5: 39435c82e5a007ef64cbb153ecc40cfd
@@ -1135,31 +2164,6 @@ packages:
   purls: []
   size: 23995
   timestamp: 1749230346887
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_1.conda
-  sha256: 1f66e240fd37f66dfaff27f55f0e69008c4fdbbb02766cd2e0a60d2de85d49b4
-  md5: 23d49402c43d1ea67aca3685acedc0ae
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - liblzma 5.8.1 hb9d3cd8_1
-  constrains:
-  - xz 5.8.1.*
-  - xz ==5.8.1=*_1
-  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
-  purls: []
-  size: 33852
-  timestamp: 1746531515485
-- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-gpl-tools-5.8.1-h357f2ed_2.conda
-  sha256: 5cdadfff31de7f50d1b2f919dd80697c0a08d90f8d6fb89f00c93751ec135c3c
-  md5: d4044359fad6af47224e9ef483118378
-  depends:
-  - __osx >=10.13
-  - liblzma 5.8.1 hd471939_2
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
-  size: 33890
-  timestamp: 1749230206830
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
   sha256: a0790cfb48d240e7b655b0d797a00040219cf39e3ee38e2104e548515df4f9c2
   md5: 09b1442c1d49ac7c5f758c44695e77d1
@@ -1172,31 +2176,6 @@ packages:
   purls: []
   size: 34103
   timestamp: 1749230329933
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_1.conda
-  sha256: d219c162f2bf0bb851bfe4fbcb70f118b4f518e0e1c46ae72726bc5b9dde6f24
-  md5: 966d5f3958ecfaf49a9a060dfb81eb85
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - liblzma 5.8.1 hb9d3cd8_1
-  constrains:
-  - xz 5.8.1.*
-  - xz ==5.8.1=*_1
-  license: 0BSD AND LGPL-2.1-or-later
-  purls: []
-  size: 96134
-  timestamp: 1746531500507
-- conda: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.8.1-hd471939_2.conda
-  sha256: 3b1d8958f8dceaa4442100d5326b2ec9bcc2e8d7ee55345bf7101dc362fb9868
-  md5: 349148960ad74aece88028f2b5c62c51
-  depends:
-  - __osx >=10.13
-  - liblzma 5.8.1 hd471939_2
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD AND LGPL-2.1-or-later
-  size: 85777
-  timestamp: 1749230191007
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.1-h39f12f2_2.conda
   sha256: 9d1232705e3d175f600dc8e344af9182d0341cdaa73d25330591a28532951063
   md5: 37996935aa33138fca43e4b4563b6a28

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ build = { cmd = "maturin build --release --features python" }
 
 
 develop = { cmd = "./scripts/build_and_install.sh --features python" }
+# Linux-only: builds the extension with eBPF so execute_with_monitoring(enable_ebpf=True)
+# actually attaches (per-process network etc). Needs clang; shipped wheels stay python-only.
+develop-ebpf = { cmd = "./scripts/build_and_install.sh --features python,ebpf" }
 test = { cmd = "python -m pytest -n 4 tests/python/" }
 
 # 2 workers for github runners

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 
+[project.optional-dependencies]
+report = ["altair>=5.0", "pandas>=2.0", "vl-convert-python>=1.0"]
+
+[project.scripts]
+denet-report = "denet.report:main"
+
 [tool.pixi.workspace]
 name = "denet"
 version = "0.7.2"
@@ -36,6 +42,9 @@ pytest = ">=7.0.0"
 pytest-cov = ">=4.1.0"
 pytest-xdist = ">=3.7.0,<4"
 ruff = ">=0.1.0"
+altair = ">=5.0"
+pandas = ">=2.0"
+vl-convert-python = ">=1.0"
 
 [tool.pixi.tasks]
 build = { cmd = "maturin build --release --features python" }

--- a/python/denet/__init__.py
+++ b/python/denet/__init__.py
@@ -71,6 +71,7 @@ def execute_with_monitoring(
     quiet: bool = False,
     include_children: bool = True,
     write_metadata: bool = False,
+    enable_ebpf: bool = False,
 ) -> Tuple[int, "ProcessMonitor"]:
     """
     Execute a command with monitoring from the very start using signal-based process control.
@@ -97,6 +98,8 @@ def execute_with_monitoring(
         quiet: Whether to suppress output
         include_children: Whether to monitor child processes (default True)
         write_metadata: Whether to write metadata as first line to output file (default False)
+        enable_ebpf: Enable eBPF profiling incl. per-process network bytes (default False).
+            Needs CAP_BPF+CAP_PERFMON (root or setcap); degrades to a warning otherwise.
 
     Returns:
         Tuple of (exit_code, monitor)
@@ -149,6 +152,7 @@ def execute_with_monitoring(
                 quiet=quiet,
                 include_children=include_children,
                 write_metadata=write_metadata,
+                enable_ebpf=enable_ebpf,
             )
 
             # 4. Resume the process if it was paused

--- a/python/denet/__init__.py
+++ b/python/denet/__init__.py
@@ -18,6 +18,16 @@ from .analysis import (
 
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
+
+def __getattr__(name):
+    # Lazy so `python -m denet.report` doesn't double-import the module
+    if name == "generate_report":
+        from .report import generate_report
+
+        return generate_report
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 try:
     __version__ = _pkg_version("denet")
 except PackageNotFoundError:  # pragma: no cover - source tree, denet not installed
@@ -35,6 +45,7 @@ __all__ = [
     "resource_utilization",
     "save_metrics",
     "execute_with_monitoring",
+    "generate_report",
 ]
 
 import os

--- a/python/denet/report.py
+++ b/python/denet/report.py
@@ -102,6 +102,59 @@ def _to_frame(rows: list[dict[str, Any]]):
     return df, per_process
 
 
+def _per_child_net_frame(rows: list[dict[str, Any]]):
+    """Per-PID network rates from ``ebpf.network.per_pid``.
+
+    Returns a long DataFrame ``[t, pid, dir, rate]`` (bytes/s) covering only the
+    PIDs that actually moved bytes, or None when the breakdown is absent or just
+    one PID was active — a single active PID is already the main network panel,
+    so splitting it out adds nothing. Retired children drop out of per_pid; a
+    resulting negative cumulative diff is clipped to 0.
+    """
+    import pandas as pd
+
+    t0 = rows[0]["ts_ms"]
+    recs = []
+    for m in rows:
+        per_pid = ((m.get("ebpf") or {}).get("network") or {}).get("per_pid") or {}
+        t = (m["ts_ms"] - t0) / 1000.0
+        for pid, b in per_pid.items():
+            recs.append({"t": t, "pid": int(pid), "rx": b.get("rx_bytes", 0), "tx": b.get("tx_bytes", 0)})
+    if not recs:
+        return None
+
+    df = pd.DataFrame(recs).sort_values(["pid", "t"])
+    g = df.groupby("pid")
+    dt = g["t"].diff()
+    df["rx_rate"] = (g["rx"].diff().clip(lower=0) / dt).fillna(0)
+    df["tx_rate"] = (g["tx"].diff().clip(lower=0) / dt).fillna(0)
+
+    active = [pid for pid, sub in df.groupby("pid") if sub["rx"].max() + sub["tx"].max() > 0]
+    if len(active) < 2:
+        return None
+    df = df[df["pid"].isin(active)]
+    long = df.melt(id_vars=["t", "pid"], value_vars=["rx_rate", "tx_rate"], var_name="dir", value_name="rate")
+    long["dir"] = long["dir"].str.removesuffix("_rate")
+    return long
+
+
+def _per_child_net_chart(alt, long, width: int):
+    """One small network timeline per PID (facet row), when >1 PID was active."""
+    if long is None:
+        return None
+    return (
+        alt.Chart(long)
+        .mark_line(point=True)
+        .encode(
+            x=alt.X("t:Q", title="elapsed (s)"),
+            y=alt.Y("rate:Q", title="bytes/s"),
+            color=alt.Color("dir:N", title=None),
+        )
+        .properties(width=width, height=80)
+        .facet(row=alt.Row("pid:N", title="per-PID network (eBPF)"))
+    )
+
+
 def _slotted(df):
     """Aggregate into at most MAX_SLOTS time slots (mean gauges, max rates)."""
     if len(df) <= MAX_SLOTS or df["t"].iloc[-1] <= 0:
@@ -379,6 +432,12 @@ def generate_report(input_path: str, output_path: str | None = None, fmt: str | 
     ).properties(width=width, height=height)
 
     panels = [cpu, mem, net]
+
+    # eBPF-only: split network by PID when >1 child moved bytes (bands omitted —
+    # this is a drill-down under the aggregate net panel, not a main timeline)
+    child_net = _per_child_net_chart(alt, _per_child_net_frame(rows), width)
+    if child_net is not None:
+        panels.append(child_net)
 
     # memory-pressure (PSI) timeline — only when there was actual pressure
     psi_df = _psi_frame(rows)

--- a/python/denet/report.py
+++ b/python/denet/report.py
@@ -1,0 +1,475 @@
+"""
+denet.report: Generate a static HTML report from a denet JSONL file.
+
+Renders CPU, memory, and network timelines with Altair/Vega-Lite, plus a
+header stating which optional capabilities (eBPF, PSI, perf counters) the
+run had. Requires the ``report`` extra: ``pip install denet[report]``.
+
+Usage:
+    python -m denet.report metrics.jsonl -o report.html
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+MAX_SLOTS = 512  # ponytail: fixed slot budget; make it a CLI flag if someone needs finer resolution
+
+
+def _load_records(path: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Parse a denet JSONL file into (metadata, sample rows).
+
+    Handles both kind-tagged and legacy untagged files. Each row is the
+    aggregated metrics of a tree record (falling back to parent), or the
+    sample itself in single-process mode.
+    """
+    meta: dict[str, Any] = {}
+    rows: list[dict[str, Any]] = []
+    ebpf_seen = False
+
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(rec, dict):
+                continue
+
+            kind = rec.get("kind")
+            if kind is None:  # legacy untagged: infer from shape
+                if "cmd" in rec:
+                    kind = "metadata"
+                elif "aggregated" in rec or "children" in rec:
+                    kind = "tree"
+                elif "cpu_usage" in rec:
+                    kind = "sample"
+                else:
+                    continue  # env record, stats tail, unknown
+
+            if kind == "metadata":
+                meta = rec
+            elif kind == "tree":
+                m = rec.get("aggregated") or rec.get("parent")
+                if m:
+                    ebpf_seen = ebpf_seen or "ebpf" in m
+                    rows.append({**m, "ts_ms": rec["ts_ms"]})
+            elif kind == "sample":
+                ebpf_seen = ebpf_seen or "ebpf" in rec
+                rows.append(rec)
+
+    meta["_ebpf_seen"] = ebpf_seen
+    return meta, rows
+
+
+def _to_frame(rows: list[dict[str, Any]]):
+    """Build a DataFrame with elapsed seconds and per-second rates."""
+    import pandas as pd
+
+    def net(m: dict[str, Any], direction: str) -> int:
+        # sys_net_* with legacy net_* alias
+        v = m.get(f"sys_net_{direction}_bytes")
+        return v if v is not None else m.get(f"net_{direction}_bytes", 0)
+
+    def ebpf_net(m: dict[str, Any], direction: str):
+        return ((m.get("ebpf") or {}).get("network") or {}).get(f"{direction}_bytes")
+
+    df = pd.DataFrame(
+        {
+            "ts_ms": m["ts_ms"],
+            "cpu": m.get("cpu_usage", 0.0),
+            "mem_mib": m.get("mem_rss_kb", 0) / 1024.0,
+            "rx": net(m, "rx"),
+            "tx": net(m, "tx"),
+            "ebpf_rx": ebpf_net(m, "rx"),
+            "ebpf_tx": ebpf_net(m, "tx"),
+        }
+        for m in rows
+    )
+    df["t"] = (df["ts_ms"] - df["ts_ms"].iloc[0]) / 1000.0
+
+    # Per-process eBPF bytes when available, system-wide otherwise.
+    per_process = df["ebpf_rx"].notna().any()
+    rx, tx = ("ebpf_rx", "ebpf_tx") if per_process else ("rx", "tx")
+    # Counters are cumulative; diff to per-sample deltas, then to bytes/s.
+    dt = df["t"].diff()
+    df["rx_rate"] = (df[rx].diff().clip(lower=0) / dt).fillna(0)
+    df["tx_rate"] = (df[tx].diff().clip(lower=0) / dt).fillna(0)
+    return df, per_process
+
+
+def _slotted(df):
+    """Aggregate into at most MAX_SLOTS time slots (mean gauges, max rates)."""
+    if len(df) <= MAX_SLOTS or df["t"].iloc[-1] <= 0:
+        return df
+    slot = df["t"].iloc[-1] / MAX_SLOTS
+    return (
+        df.groupby((df["t"] // slot) * slot)
+        .agg({"cpu": "mean", "mem_mib": "mean", "rx_rate": "max", "tx_rate": "max"})
+        .rename_axis("t")
+        .reset_index()
+    )
+
+
+def _detect_regimes(df, max_regimes: int = 6) -> list[dict[str, Any]]:
+    """Segment the run into piecewise-constant regimes via binary segmentation.
+
+    Runs on the slotted series (<= MAX_SLOTS points), jointly over the z-scored
+    CPU / memory / network signals. Splits are accepted while the SSE gain beats
+    a BIC-style penalty; caps at ``max_regimes``. Returns [] for short runs.
+    """
+    import numpy as np
+
+    cols = [c for c in ("cpu", "mem_mib", "rx_rate", "tx_rate") if c in df.columns]
+    n = len(df)
+    if n < 8 or not cols:
+        return []
+
+    x = df[cols].to_numpy(dtype=float)
+    std = x.std(axis=0)
+    std[std == 0] = 1.0
+    z = (x - x.mean(axis=0)) / std
+    # prefix sums so any segment's SSE is O(1)
+    p1 = np.vstack([np.zeros(z.shape[1]), np.cumsum(z, axis=0)])
+    p2 = np.vstack([np.zeros(z.shape[1]), np.cumsum(z * z, axis=0)])
+
+    def sse(a: int, b: int) -> float:  # SSE of z[a:b] under a constant mean
+        s1, s2 = p1[b] - p1[a], p2[b] - p2[a]
+        return float(np.sum(s2 - (s1 * s1) / (b - a)))
+
+    min_size = max(2, n // 50)
+    penalty = len(cols) * float(np.log(n))  # ponytail: BIC-ish stop rule; tune if it over/under-splits real runs
+    segs = [(0, n)]
+    while len(segs) < max_regimes:
+        best = None  # (gain, seg_index, split_point)
+        for i, (a, b) in enumerate(segs):
+            if b - a < 2 * min_size:
+                continue
+            base = sse(a, b)
+            for k in range(a + min_size, b - min_size + 1):
+                gain = base - sse(a, k) - sse(k, b)
+                if best is None or gain > best[0]:
+                    best = (gain, i, k)
+        if best is None or best[0] < penalty:
+            break
+        _, i, k = best
+        a, b = segs[i]
+        segs[i : i + 1] = [(a, k), (k, b)]
+
+    # logical z-signals for the "dominant activity" label (net = mean of rx/tx z)
+    zc = {c: z[:, i] for i, c in enumerate(cols)}
+    signals = {"cpu": zc.get("cpu"), "memory": zc.get("mem_mib")}
+    if "rx_rate" in zc and "tx_rate" in zc:
+        signals["network"] = (zc["rx_rate"] + zc["tx_rate"]) / 2
+
+    segs.sort()
+    t = df["t"].to_numpy()
+    regimes = []
+    for a, b in segs:
+        # dominant = signal most elevated above the run's own average in this regime;
+        # if none rises meaningfully above average, it's an idle/low phase.
+        means = {k: float(v[a:b].mean()) for k, v in signals.items() if v is not None}
+        top = max(means, key=means.get)
+        regimes.append(
+            {
+                "t0": float(t[a]),
+                "t1": float(t[b - 1]),
+                "cpu": float(df["cpu"].iloc[a:b].mean()),
+                "mem_mib": float(df["mem_mib"].iloc[a:b].mean()),
+                "dominant": top if means[top] > 0.3 else "idle/low",
+            }
+        )
+    return regimes
+
+
+def _syscall_frame(rows: list[dict[str, Any]]):
+    """Frame of eBPF syscall counts per category over time, or None.
+
+    Time base matches `_to_frame` (first row). Each sample's counts are the sum
+    over the currently-alive monitored PIDs, so the totals rise and fall as
+    short-lived children come and go (not a clean cumulative counter).
+    """
+    import pandas as pd
+
+    cats: set[str] = set()
+    for m in rows:
+        sc = ((m.get("ebpf") or {}).get("syscalls") or {}).get("by_category") or {}
+        cats.update(sc)
+    if not cats:
+        return None
+
+    base = rows[0]["ts_ms"]
+    recs = []
+    for m in rows:
+        sc = ((m.get("ebpf") or {}).get("syscalls") or {}).get("by_category") or {}
+        recs.append({"t": (m["ts_ms"] - base) / 1000.0, **{c: sc.get(c, 0) for c in cats}})
+    return pd.DataFrame(recs)
+
+
+def _syscalls_per_regime(sc_df, regimes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Mean per-sample syscall counts per category within each regime → [{regime, category, count}].
+
+    The underlying counts are alive-PID snapshots (see `_syscall_frame`), not
+    clean per-window deltas, so the mean of the snapshots in a regime is used as
+    a proxy for that phase's typical syscall mix. Because the chart normalizes
+    each regime's bar, mean vs sum yields identical proportions.
+    """
+    spans = regimes or [{"t0": float(sc_df["t"].min()), "t1": float(sc_df["t"].max())}]
+    cats = [c for c in sc_df.columns if c != "t"]
+    out = []
+    for i, r in enumerate(spans):
+        span = sc_df[(sc_df["t"] >= r["t0"]) & (sc_df["t"] <= r["t1"])]
+        if span.empty:
+            continue
+        for c in cats:
+            val = float(span[c].mean())
+            if val > 0:
+                out.append({"regime": f"R{i + 1}", "category": c, "count": val})
+    return out
+
+
+def _syscall_chart(alt, breakdown: list[dict[str, Any]], width: int, regime_labels: list[str]):
+    """Normalized stacked bar of syscall category mix per regime, or None.
+
+    All regimes stay on the axis (via the y-scale domain) so the rows line up
+    with the regime table; a regime with no syscalls shows as an empty row.
+    """
+    import pandas as pd
+
+    if not breakdown:
+        return None
+    return (
+        alt.Chart(pd.DataFrame(breakdown))
+        .mark_bar()
+        .encode(
+            y=alt.Y("regime:N", title=None, sort=regime_labels, scale=alt.Scale(domain=regime_labels)),
+            x=alt.X("count:Q", stack="normalize", title="syscall mix (share of calls)"),
+            color=alt.Color("category:N", title="syscall category"),
+            order=alt.Order("category:N"),
+            tooltip=["regime:N", "category:N", "count:Q"],
+        )
+        .properties(width=width, height=34 * len(regime_labels) + 10, title="Syscalls by category, per regime (eBPF)")
+    )
+
+
+def _psi_frame(rows: list[dict[str, Any]]):
+    """Frame of memory-pressure (PSI) percentages over time, or None.
+
+    Shown whenever PSI was recorded (a flat-zero trace is a meaningful "no
+    memory pressure" reading, and matches the PSI capability in the header).
+    Returns None only when no `psi_mem` is present at all.
+    """
+    import pandas as pd
+
+    if not any("psi_mem" in m for m in rows):
+        return None
+    base = rows[0]["ts_ms"]
+    recs = []
+    for m in rows:
+        p = m.get("psi_mem") or {}
+        recs.append(
+            {
+                "t": (m["ts_ms"] - base) / 1000.0,
+                "some": p.get("some_avg10", 0.0),
+                "full": p.get("full_avg10", 0.0),
+            }
+        )
+    return pd.DataFrame(recs)
+
+
+def _capability_line(meta: dict[str, Any], per_process_net: bool) -> str:
+    caps = meta.get("capabilities") or {}
+
+    def avail(name: str, *keys: str) -> str:
+        # perf_hw uses {available}; psi uses {system, per_process}. Any truthy key counts.
+        c = caps.get(name) or {}
+        return "yes" if any(c.get(k) for k in keys) else "no"
+
+    net_src = "per-process (eBPF)" if per_process_net else "system-wide approximation"
+    ebpf = "yes" if meta.get("_ebpf_seen") else "no"
+    psi = avail("psi", "available", "system", "per_process")
+    perf = avail("perf_hw", "available")
+    return f"eBPF: {ebpf} | network: {net_src} | PSI: {psi} | perf counters: {perf}"
+
+
+def _regime_table(alt, regimes: list[dict[str, Any]], width: int):
+    """Render the detected regimes as a compact text-grid table, or None."""
+    import pandas as pd
+
+    if not regimes:
+        return None
+    cells = []
+    for i, r in enumerate(regimes):
+        vals = {
+            "span (s)": f"{r['t0']:.1f}–{r['t1']:.1f}",
+            "mean CPU %": f"{r['cpu']:.0f}",
+            "mean RSS MiB": f"{r['mem_mib']:.0f}",
+            "dominant": r["dominant"],
+        }
+        for col, val in vals.items():
+            cells.append({"regime": f"R{i + 1}", "metric": col, "value": val})
+    order = ["span (s)", "mean CPU %", "mean RSS MiB", "dominant"]
+    return (
+        alt.Chart(pd.DataFrame(cells))
+        .mark_text()
+        .encode(
+            x=alt.X("metric:N", sort=order, axis=alt.Axis(orient="top", labelAngle=0), title=None),
+            y=alt.Y("regime:N", title=None),
+            text="value:N",
+        )
+        .properties(width=width, height=22 * len(regimes) + 10, title="Detected regimes")
+    )
+
+
+def generate_report(input_path: str, output_path: str | None = None, fmt: str | None = None) -> str:
+    """Generate a report from a denet JSONL file.
+
+    fmt is one of "html" (default; interactive, self-contained), "png", or "svg"
+    (both static, no JS). When fmt is None it is inferred from output_path's
+    extension, falling back to html. Returns the path of the written file.
+    """
+    try:
+        import altair as alt
+    except ImportError as e:
+        raise ImportError("The report feature needs extra dependencies: pip install denet[report]") from e
+
+    meta, rows = _load_records(input_path)
+    if not rows:
+        raise ValueError(f"No metric records found in {input_path}")
+
+    df, per_process_net = _to_frame(rows)
+    duration = df["t"].iloc[-1]
+    df = _slotted(df)
+    regimes = _detect_regimes(df)
+
+    x = alt.X("t:Q", title="elapsed (s)")
+    width, height = 700, 150
+
+    def bands():
+        # shade alternating regimes so phase boundaries are visible under every timeline
+        import pandas as pd
+
+        odd = [{"t0": r["t0"], "t1": r["t1"]} for r in regimes[1::2]]
+        if not odd:
+            return None
+        return alt.Chart(pd.DataFrame(odd)).mark_rect(opacity=0.10, color="#888").encode(x="t0:Q", x2="t1:Q")
+
+    band = bands()
+
+    def timeline(chart):
+        return alt.layer(band, chart) if band is not None else chart
+
+    # point=True so a 1-2 sample run still shows a visible dot (a line through one point draws nothing)
+    cpu = timeline(alt.Chart(df).mark_line(point=True).encode(x=x, y=alt.Y("cpu:Q", title="CPU (%)"))).properties(
+        width=width, height=height
+    )
+    mem = timeline(alt.Chart(df).mark_line(point=True).encode(x=x, y=alt.Y("mem_mib:Q", title="RSS (MiB)"))).properties(
+        width=width, height=height
+    )
+    net_df = df.melt(id_vars="t", value_vars=["rx_rate", "tx_rate"], var_name="dir", value_name="rate")
+    net_df["dir"] = net_df["dir"].str.removesuffix("_rate")
+    net = timeline(
+        alt.Chart(net_df)
+        .mark_line(point=True)
+        .encode(x=x, y=alt.Y("rate:Q", title="network (bytes/s)"), color=alt.Color("dir:N", title=None))
+    ).properties(width=width, height=height)
+
+    panels = [cpu, mem, net]
+
+    # memory-pressure (PSI) timeline — only when there was actual pressure
+    psi_df = _psi_frame(rows)
+    if psi_df is not None:
+        psi_long = psi_df.melt(id_vars="t", value_vars=["some", "full"], var_name="scope", value_name="pct")
+        panels.append(
+            timeline(
+                alt.Chart(psi_long)
+                .mark_line(point=True)
+                .encode(
+                    x=x,
+                    y=alt.Y("pct:Q", title="mem stall (% / 10s)"),
+                    color=alt.Color("scope:N", title="PSI"),
+                )
+            ).properties(width=width, height=height)
+        )
+
+    table = _regime_table(alt, regimes, width)
+    if table is not None:
+        panels.append(table)
+
+    # eBPF-only: syscall category mix per regime
+    sc_df = _syscall_frame(rows)
+    if sc_df is not None:
+        labels = [f"R{i + 1}" for i in range(len(regimes))] or ["R1"]
+        sc_chart = _syscall_chart(alt, _syscalls_per_regime(sc_df, regimes), width, labels)
+        if sc_chart is not None:
+            panels.append(sc_chart)
+
+    # collapse whitespace (a -c script can embed newlines that break the title) and cap length
+    cmd = " ".join(" ".join(meta.get("cmd", [])).split()) or "(unknown command)"
+    if len(cmd) > 90:
+        cmd = cmd[:87] + "..."
+    subtitle = [f"{len(rows)} samples over {duration:.1f}s", _capability_line(meta, per_process_net)]
+    if len(rows) < 3:
+        subtitle.append("warning: too few samples for a timeline — did the process exit early?")
+    chart = (
+        alt.vconcat(*panels)
+        .resolve_scale(color="independent")  # keep net rx/tx and syscall-category legends separate
+        .properties(title=alt.TitleParams(text=f"denet report: {cmd}", subtitle=subtitle, anchor="start"))
+    )
+
+    # format: explicit arg > -o extension > html. png/svg are fully static (no JS).
+    if fmt is None:
+        ext = Path(output_path).suffix.lower().lstrip(".") if output_path else ""
+        fmt = ext if ext in ("html", "png", "svg") else "html"
+    out = output_path or str(Path(input_path).with_suffix("." + fmt))
+    if fmt == "html":
+        try:
+            chart.save(out, inline=True)  # self-contained, needs vl-convert-python
+        except (ImportError, ValueError):
+            chart.save(out)  # falls back to CDN-loaded vega scripts
+    elif fmt == "png":
+        chart.save(out, scale_factor=2)  # vl-convert renders a static raster
+    else:  # svg — static vector
+        chart.save(out)
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="denet-report",
+        description="Generate a report (CPU/memory/network timelines, regime detection, "
+        "and eBPF syscall breakdown) from a denet JSONL metrics file.",
+        epilog=(
+            "formats:\n"
+            "  html  interactive, self-contained (JavaScript); the default. Open in a browser.\n"
+            "  png   static raster image; opens in any viewer, editor preview, or GitHub.\n"
+            "  svg   static vector image; no JavaScript.\n\n"
+            "examples:\n"
+            "  denet-report metrics.jsonl                 # -> metrics.html (interactive)\n"
+            "  denet-report metrics.jsonl -o out.png      # static PNG (format from extension)\n"
+            "  denet-report metrics.jsonl -f svg -o r.svg # static SVG"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("input", help="denet JSONL metrics file")
+    parser.add_argument("-o", "--output", help="output path (default: <input>.<format>)")
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["html", "png", "svg"],
+        help="output format. Default: inferred from -o's extension, else html. "
+        "html is interactive (JS); png and svg are static.",
+    )
+    args = parser.parse_args()
+    try:
+        print(generate_report(args.input, args.output, args.format))
+    except (ImportError, ValueError, FileNotFoundError) as e:
+        raise SystemExit(f"denet-report: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -25,6 +25,32 @@ This example:
 - Tracking the number of processes over time
 - Generating summary statistics for the entire monitoring session
 
+## Profiling a Real Pipeline (scanpy)
+
+`scanpy_pbmc.py` is a small single-cell workload — it downloads the pbmc3k
+dataset and runs filter → normalize → PCA → neighbor graph → Leiden clustering.
+Unlike the examples above, it doesn't use the denet API; it's a realistic thing
+to *profile*, with naturally distinct phases that show off denet's report and
+regime detection.
+
+It declares its own dependencies with [PEP 723](https://peps.python.org/pep-0723/)
+inline metadata, so [uv](https://docs.astral.sh/uv/) installs scanpy into an
+ephemeral environment automatically:
+
+```bash
+# run it directly
+uv run scanpy_pbmc.py
+
+# or profile it and turn the run into a report
+denet run --json --out scanpy.jsonl uv run scanpy_pbmc.py
+denet-report scanpy.jsonl -o scanpy.html   # needs: pip install denet[report]
+```
+
+The report's regime detection typically separates the phases cleanly: a heavy
+import/startup phase, the dataset download (network), the multi-core PCA +
+neighbor-graph phase, and the single-threaded clustering phase. See
+[docs/python-api.md](../../docs/python-api.md#reports) for the report options.
+
 ## Additional Examples
 
 More examples will be added in the future. If you have a specific use case you'd like to see demonstrated, please open an issue on our GitHub repository.

--- a/python/examples/network_children.py
+++ b/python/examples/network_children.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Per-child network breakdown, driven from the Python API.
+
+Runs two curls (each piped to sha256sum, so every child does network + CPU) as
+children under denet with eBPF per-process accounting on, then renders a report.
+The two downloads show up as separate PIDs in the report's "per-PID network
+(eBPF)" widget.
+
+Requires an eBPF-enabled build and CAP_BPF+CAP_PERFMON:
+  - Linux pip wheels ship with eBPF; from a source checkout build it with
+    `pixi run develop-ebpf` (needs clang).
+  - Run with sudo, or `setcap cap_bpf,cap_perfmon+ep` on the python binary.
+Without eBPF or caps the run still works — you just get the aggregate network
+panel and no per-PID split (enable_ebpf degrades to a logged warning).
+"""
+
+import os
+
+import denet
+from denet.report import generate_report
+
+# Two different files (distinct sizes) from Cloudflare's speed endpoint.
+URL1 = os.environ.get("URL1", "https://speed.cloudflare.com/__down?bytes=20000000")
+URL2 = os.environ.get("URL2", "https://speed.cloudflare.com/__down?bytes=40000000")
+OUT = os.environ.get("OUT", "network_children.jsonl")
+
+cmd = ["bash", "-c", f"curl -sL '{URL1}' | sha256sum & curl -sL '{URL2}' | sha256sum & wait"]
+
+exit_code, _monitor = denet.execute_with_monitoring(
+    cmd,
+    base_interval_ms=100,
+    output_file=OUT,
+    enable_ebpf=True,
+    quiet=True,
+)
+print(f"monitored command exited {exit_code}; samples written to {OUT}")
+
+report = generate_report(OUT)
+print(f"report written: {report}")

--- a/python/examples/network_children.sh
+++ b/python/examples/network_children.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Per-child network breakdown demo.
+#
+# Runs two curls as children under denet, each piped to sha256sum so every
+# child does both network (curl) and CPU (hashing) work. With eBPF per-process
+# accounting on, the two downloads land under separate PIDs, and the generated
+# report grows a "per-PID network (eBPF)" widget — one small timeline per child.
+#
+# eBPF needs CAP_BPF+CAP_PERFMON: run this with sudo, or setcap the denet
+# binary. Without caps the report still renders, just without the per-PID
+# widget (the aggregate network panel is unaffected).
+#
+# Overridable via env: URL1, URL2, OUT, DENET.
+set -euo pipefail
+
+# Two different files (distinct sizes) from Cloudflare's speed endpoint — no
+# account needed and reliably up. Swap for any two URLs you like.
+URL1="${URL1:-https://speed.cloudflare.com/__down?bytes=20000000}"
+URL2="${URL2:-https://speed.cloudflare.com/__down?bytes=40000000}"
+OUT="${OUT:-network_children.jsonl}"
+
+# Prefer an installed denet; fall back to building from this checkout.
+DENET="${DENET:-denet}"
+command -v "$DENET" >/dev/null 2>&1 || DENET="cargo run --release --features ebpf --bin denet --"
+
+$DENET --enable-ebpf --out "$OUT" run -- \
+    bash -c "curl -sL '$URL1' | sha256sum & curl -sL '$URL2' | sha256sum & wait"
+
+python3 -m denet.report "$OUT"
+echo "report written: ${OUT%.jsonl}.html"

--- a/python/examples/scanpy_pbmc.py
+++ b/python/examples/scanpy_pbmc.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["scanpy", "leidenalg", "igraph", "numpy<2"]
+# ///
+"""A small, real single-cell pipeline: download the pbmc3k dataset from scanpy,
+then filter -> normalize -> PCA -> neighbor graph -> Leiden clustering.
+
+It's meant as a workload to *profile* with denet, not a denet API example. The
+pipeline has naturally distinct phases (import / download / PCA / neighbors /
+cluster), so it's a good showcase for denet's report and regime detection.
+
+Run standalone (uv installs the deps into an ephemeral env):
+
+    uv run scanpy_pbmc.py
+
+Profile it and build a report:
+
+    denet run --json --out scanpy.jsonl uv run scanpy_pbmc.py
+    denet-report scanpy.jsonl -o scanpy.html   # needs: pip install denet[report]
+"""
+
+import scanpy as sc
+
+sc.settings.verbosity = 1
+
+# 1. download (network) — ~5.9 MB h5ad, cached under ./data after first run
+adata = sc.datasets.pbmc3k()
+
+# 2. preprocess (file/CPU) — basic QC filtering, normalization, log transform
+sc.pp.filter_cells(adata, min_genes=200)
+sc.pp.filter_genes(adata, min_cells=3)
+sc.pp.normalize_total(adata, target_sum=1e4)
+sc.pp.log1p(adata)
+sc.pp.highly_variable_genes(adata, n_top_genes=2000)
+adata = adata[:, adata.var.highly_variable].copy()
+sc.pp.scale(adata, max_value=10)
+
+# 3. PCA (CPU + memory)
+sc.tl.pca(adata, n_comps=50)
+
+# 4. neighbor graph (CPU heavy)
+sc.pp.neighbors(adata, n_neighbors=15, n_pcs=40)
+
+# 5. Leiden clustering (CPU)
+sc.tl.leiden(adata, flavor="igraph", n_iterations=2, directed=False)
+
+print(f"cells x genes: {adata.n_obs} x {adata.n_vars}")
+print("cluster sizes:")
+print(adata.obs["leiden"].value_counts().sort_index())

--- a/scripts/build_and_install.sh
+++ b/scripts/build_and_install.sh
@@ -8,8 +8,10 @@ cd "$(dirname "$0")/.."
 
 echo "🔨 Building and installing denet with maturin develop..."
 
-# Use maturin develop to build and install in editable mode
-maturin develop --release
+# Use maturin develop to build and install in editable mode.
+# Forward extra args (e.g. --features python,ebpf) to maturin; they add to the
+# features configured in pyproject.toml's [tool.maturin].
+maturin develop --release "$@"
 
 # Verify the installation
 echo "Verifying installation..."

--- a/src/bin/denet.rs
+++ b/src/bin/denet.rs
@@ -80,7 +80,7 @@ enum Commands {
     /// Run and monitor a new process
     Run {
         /// Command to run and monitor
-        #[clap(required = true)]
+        #[clap(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
     },
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -51,10 +51,20 @@ fn build_output_config(
     Ok(builder.build())
 }
 
+/// Enable eBPF on a monitor if requested, warning-and-continuing on failure
+/// (missing caps, non-eBPF build) — same graceful degradation as the CLI.
+fn maybe_enable_ebpf(inner: &mut ProcessMonitor, enable_ebpf: bool) {
+    if enable_ebpf {
+        if let Err(e) = inner.enable_ebpf() {
+            log::warn!("Failed to enable eBPF profiling: {e}");
+        }
+    }
+}
+
 #[pymethods]
 impl PyProcessMonitor {
     #[new]
-    #[pyo3(signature = (cmd, base_interval_ms, max_interval_ms, since_process_start=false, output_file=None, output_format="jsonl", store_in_memory=true, quiet=false, include_children=true, write_metadata=false, write_env=false))]
+    #[pyo3(signature = (cmd, base_interval_ms, max_interval_ms, since_process_start=false, output_file=None, output_format="jsonl", store_in_memory=true, quiet=false, include_children=true, write_metadata=false, write_env=false, enable_ebpf=false))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         cmd: Vec<String>,
@@ -68,6 +78,7 @@ impl PyProcessMonitor {
         include_children: bool,
         write_metadata: bool,
         write_env: bool,
+        enable_ebpf: bool,
     ) -> PyResult<Self> {
         let output_config = build_output_config(
             output_file,
@@ -88,6 +99,7 @@ impl PyProcessMonitor {
 
         // Enable child process monitoring if requested
         inner.set_include_children(include_children);
+        maybe_enable_ebpf(&mut inner, enable_ebpf);
 
         Ok(PyProcessMonitor {
             inner,
@@ -100,7 +112,7 @@ impl PyProcessMonitor {
 
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (pid, base_interval_ms, max_interval_ms, since_process_start=false, output_file=None, output_format="jsonl", store_in_memory=true, quiet=false, include_children=true, write_metadata=false, write_env=false))]
+    #[pyo3(signature = (pid, base_interval_ms, max_interval_ms, since_process_start=false, output_file=None, output_format="jsonl", store_in_memory=true, quiet=false, include_children=true, write_metadata=false, write_env=false, enable_ebpf=false))]
     fn from_pid(
         pid: usize,
         base_interval_ms: u64,
@@ -113,6 +125,7 @@ impl PyProcessMonitor {
         include_children: bool,
         write_metadata: Option<bool>,
         write_env: Option<bool>,
+        enable_ebpf: bool,
     ) -> PyResult<Self> {
         let output_config = build_output_config(
             output_file,
@@ -132,6 +145,7 @@ impl PyProcessMonitor {
 
         // Enable child process monitoring if requested
         inner.set_include_children(include_children);
+        maybe_enable_ebpf(&mut inner, enable_ebpf);
 
         Ok(PyProcessMonitor {
             inner,
@@ -144,7 +158,7 @@ impl PyProcessMonitor {
 
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (cmd, stdout_file=None, stderr_file=None, timeout=None, base_interval_ms=100, max_interval_ms=1000, store_in_memory=true, output_file=None, output_format="jsonl", since_process_start=false, pause_for_attachment=true, quiet=false, include_children=true))]
+    #[pyo3(signature = (cmd, stdout_file=None, stderr_file=None, timeout=None, base_interval_ms=100, max_interval_ms=1000, store_in_memory=true, output_file=None, output_format="jsonl", since_process_start=false, pause_for_attachment=true, quiet=false, include_children=true, enable_ebpf=false))]
     fn execute_with_monitoring(
         py: Python,
         cmd: Vec<String>,
@@ -160,6 +174,7 @@ impl PyProcessMonitor {
         pause_for_attachment: bool,
         quiet: bool,
         include_children: bool,
+        enable_ebpf: bool,
     ) -> PyResult<(i32, PyProcessMonitor)> {
         use std::fs::OpenOptions;
         use std::time::Duration;
@@ -242,6 +257,7 @@ impl PyProcessMonitor {
 
         // Set include_children flag
         inner.set_include_children(include_children);
+        maybe_enable_ebpf(&mut inner, enable_ebpf);
 
         let monitor = PyProcessMonitor {
             inner,

--- a/tests/python/test_report.py
+++ b/tests/python/test_report.py
@@ -331,3 +331,109 @@ def test_no_records_raises(tmp_path):
     src.write_text('{"kind":"metadata","pid":1,"cmd":["x"],"executable":"x","t0_ms":0}\n')
     with pytest.raises(ValueError, match="No metric records"):
         generate_report(str(src))
+
+
+def test_load_records_skips_junk_and_infers_legacy(tmp_path):
+    from denet.report import _load_records
+
+    p = tmp_path / "mixed.jsonl"
+    p.write_text(
+        "\n"  # blank -> skip
+        "not json{\n"  # malformed -> skip
+        "[1, 2, 3]\n"  # valid JSON but not a dict -> skip
+        + json.dumps({"pid": 1, "cmd": ["x"], "t0_ms": 0}) + "\n"  # legacy metadata (has cmd)
+        + json.dumps({"ts_ms": 10, "cpu_usage": 1.0, "mem_rss_kb": 8}) + "\n"  # legacy sample (has cpu_usage)
+        + json.dumps({"foo": "bar"}) + "\n"  # no kind/cmd/aggregated/cpu_usage -> skip
+        + json.dumps({"kind": "sample", "ts_ms": 20, "cpu_usage": 2.0, "mem_rss_kb": 8, "ebpf": {"syscalls": {}}})
+        + "\n"  # tagged sample carrying ebpf
+    )
+    meta, rows = _load_records(str(p))
+    assert meta["cmd"] == ["x"]
+    assert meta["_ebpf_seen"] is True  # set by the tagged sample's ebpf key
+    assert len(rows) == 2  # the two samples; junk and unknown records dropped
+
+
+def test_slotted_downsamples_large_run(tmp_path):
+    from denet.report import MAX_SLOTS, _load_records, _slotted, _to_frame
+
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "t0_ms": 0}]
+    records += [_tree_record(i * 100, cpu=float(i % 7), rx=i * 10) for i in range(MAX_SLOTS + 50)]
+    src = tmp_path / "big.jsonl"
+    _write_jsonl(src, records)
+    df, _ = _to_frame(_load_records(str(src))[1])
+    slotted = _slotted(df)
+    assert len(df) > MAX_SLOTS
+    # collapsed into the slot budget (+1 boundary bin from floor-division binning)
+    assert len(slotted) < len(df)
+    assert len(slotted) <= MAX_SLOTS + 1
+
+
+def test_syscall_chart_empty_breakdown_is_none():
+    import altair as alt
+
+    from denet.report import _syscall_chart
+
+    assert _syscall_chart(alt, [], 700, ["R1"]) is None
+
+
+def test_syscalls_per_regime_skips_empty_window():
+    import pandas as pd
+
+    from denet.report import _syscalls_per_regime
+
+    sc_df = pd.DataFrame([{"t": 0.0, "file_io": 5}, {"t": 1.0, "file_io": 5}])
+    # first window contains no samples (empty -> skipped), second one does
+    breakdown = _syscalls_per_regime(sc_df, [{"t0": 10.0, "t1": 20.0}, {"t0": 0.0, "t1": 1.0}])
+    assert breakdown and all(b["regime"] == "R2" for b in breakdown)
+
+
+def test_long_command_is_truncated(tmp_path):
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["run", "y" * 200], "t0_ms": 0}]
+    records += [_tree_record(i * 100, cpu=1.0, rx=i) for i in range(5)]
+    src = tmp_path / "long.jsonl"
+    _write_jsonl(src, records)
+    out = generate_report(str(src), str(tmp_path / "l.svg"))
+    assert "..." in Path(out).read_text()  # title was truncated
+
+
+def test_missing_altair_raises_friendly(tmp_path, monkeypatch):
+    import builtins
+
+    from denet import report as report_mod
+
+    _write_jsonl(
+        tmp_path / "m.jsonl",
+        [{"kind": "metadata", "pid": 1, "cmd": ["x"], "t0_ms": 0}, _tree_record(0, cpu=1.0, rx=0)],
+    )
+    real_import = builtins.__import__
+
+    def no_altair(name, *args, **kwargs):
+        if name == "altair":
+            raise ImportError("simulated missing altair")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_altair)
+    with pytest.raises(ImportError, match="report feature needs"):
+        report_mod.generate_report(str(tmp_path / "m.jsonl"))
+
+
+def test_main_cli_renders_and_errors(tmp_path, monkeypatch, capsys):
+    import sys
+
+    from denet import report as report_mod
+
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "t0_ms": 0}]
+    records += [_tree_record(i * 100, cpu=5.0, rx=i * 100) for i in range(6)]
+    src = tmp_path / "cli.jsonl"
+    _write_jsonl(src, records)
+    out = tmp_path / "cli.svg"
+
+    monkeypatch.setattr(sys, "argv", ["denet-report", str(src), "-o", str(out), "-f", "svg"])
+    report_mod.main()
+    assert out.exists()
+    assert str(out) in capsys.readouterr().out
+
+    # missing input -> caught and re-raised as SystemExit with a friendly message
+    monkeypatch.setattr(sys, "argv", ["denet-report", str(tmp_path / "nope.jsonl")])
+    with pytest.raises(SystemExit):
+        report_mod.main()

--- a/tests/python/test_report.py
+++ b/tests/python/test_report.py
@@ -109,6 +109,60 @@ def test_ebpf_net_preferred(tmp_path):
     assert "per-process (eBPF)" in (tmp_path / "r.html").read_text()
 
 
+def _tree_with_per_pid(ts_ms, per_pid):
+    """Tree record whose aggregated ebpf.network carries a per_pid breakdown."""
+    rx = sum(b["rx_bytes"] for b in per_pid.values())
+    tx = sum(b["tx_bytes"] for b in per_pid.values())
+    m = {
+        "ts_ms": ts_ms,
+        "cpu_usage": 10.0,
+        "mem_rss_kb": 1024,
+        "ebpf": {"network": {"rx_bytes": rx, "tx_bytes": tx, "per_pid": per_pid}},
+    }
+    return {"kind": "tree", "ts_ms": ts_ms, "parent": m, "children": [], "aggregated": m}
+
+
+def test_per_child_net_breakdown(tmp_path):
+    from denet.report import _per_child_net_chart, _per_child_net_frame
+
+    # two children each growing their own cumulative counters
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "executable": "x", "t0_ms": 0}]
+    records += [
+        _tree_with_per_pid(
+            i * 100,
+            {
+                "111": {"rx_bytes": i * 1000, "tx_bytes": i * 100},
+                "222": {"rx_bytes": i * 2000, "tx_bytes": 0},
+            },
+        )
+        for i in range(6)
+    ]
+    src = tmp_path / "children.jsonl"
+    _write_jsonl(src, records)
+    _, rows = _load_records(str(src))
+
+    long = _per_child_net_frame(rows)
+    assert set(long["pid"].unique()) == {111, 222}
+    # pid 222 rx: 2000 bytes per 0.1 s step -> 20000 bytes/s
+    p222_rx = long[(long["pid"] == 222) & (long["dir"] == "rx")]["rate"]
+    assert p222_rx.iloc[-1] == pytest.approx(20000)
+
+    generate_report(str(src), str(tmp_path / "r.html"))
+    assert "per-PID network (eBPF)" in (tmp_path / "r.html").read_text()
+
+    # a single active PID is not worth a breakdown -> None (and no chart)
+    solo = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "t0_ms": 0}]
+    solo += [_tree_with_per_pid(i * 100, {"111": {"rx_bytes": i * 1000, "tx_bytes": 0}}) for i in range(6)]
+    _, solo_rows = _load_records(str(_write_and_path(tmp_path / "solo.jsonl", solo)))
+    assert _per_child_net_frame(solo_rows) is None
+    assert _per_child_net_chart(None, None, 700) is None
+
+
+def _write_and_path(path, lines):
+    _write_jsonl(path, lines)
+    return path
+
+
 def test_sparse_run_warns_and_still_renders(tmp_path):
     # a process that exited early yields ~1 sample; the report must not be blank
     records = [

--- a/tests/python/test_report.py
+++ b/tests/python/test_report.py
@@ -1,0 +1,279 @@
+"""Tests for denet.report HTML report generation."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("altair")
+pytest.importorskip("pandas")
+
+from denet.report import (
+    _detect_regimes,
+    _load_records,
+    _psi_frame,
+    _slotted,
+    _syscall_chart,
+    _syscall_frame,
+    _syscalls_per_regime,
+    _to_frame,
+    generate_report,
+)
+
+
+def _write_jsonl(path, lines):
+    path.write_text("\n".join(json.dumps(rec) for rec in lines) + "\n")
+
+
+def _tree_record(ts_ms, cpu, rx, ebpf=False):
+    m = {
+        "ts_ms": ts_ms,
+        "cpu_usage": cpu,
+        "mem_rss_kb": 1024,
+        "mem_vms_kb": 4096,
+        "disk_read_bytes": 0,
+        "disk_write_bytes": 0,
+        "sys_net_rx_bytes": rx,
+        "sys_net_tx_bytes": rx // 2,
+        "thread_count": 1,
+        "process_count": 1,
+        "uptime_secs": ts_ms // 1000,
+    }
+    if ebpf:
+        m["ebpf"] = {"network": {"rx_bytes": rx * 10, "tx_bytes": rx * 5}}
+    return {"kind": "tree", "ts_ms": ts_ms, "parent": m, "children": [], "aggregated": m}
+
+
+def test_generate_report(tmp_path):
+    records = [
+        {
+            "kind": "metadata",
+            "pid": 1,
+            "cmd": ["sleep", "5"],
+            "executable": "/bin/sleep",
+            "t0_ms": 0,
+            # psi uses {system, per_process}; perf_hw uses {available} — different shapes on purpose
+            "capabilities": {
+                "psi": {"system": True, "per_process": False},
+                "perf_hw": {"available": False, "reason": "paranoid"},
+            },
+        }
+    ]
+    records += [_tree_record(i * 100, cpu=50.0, rx=i * 1000) for i in range(20)]
+    src = tmp_path / "metrics.jsonl"
+    _write_jsonl(src, records)
+
+    out = generate_report(str(src))
+
+    html = (tmp_path / "metrics.html").read_text()
+    assert out == str(tmp_path / "metrics.html")
+    assert "vega" in html.lower()
+    assert "sleep 5" in html
+    assert "eBPF: no | network: system-wide approximation | PSI: yes | perf counters: no" in html
+
+
+def test_legacy_untagged_records_and_net_alias(tmp_path):
+    records = [{"pid": 1, "cmd": ["a.out"], "executable": "a.out", "t0_ms": 0}]
+    for i in range(5):
+        m = {"ts_ms": i * 100, "cpu_usage": 1.0, "mem_rss_kb": 100, "net_rx_bytes": i * 10, "net_tx_bytes": i * 5}
+        records.append({"ts_ms": i * 100, "parent": m, "children": [], "aggregated": m})
+    src = tmp_path / "legacy.jsonl"
+    _write_jsonl(src, records)
+
+    meta, rows = _load_records(str(src))
+    assert meta["cmd"] == ["a.out"]
+    assert len(rows) == 5
+    df, per_process = _to_frame(rows)
+    assert not per_process
+    assert df["rx"].iloc[-1] == 40
+
+    out = generate_report(str(src), str(tmp_path / "r.html"))
+    assert (tmp_path / "r.html").exists()
+    assert out == str(tmp_path / "r.html")
+
+
+def test_ebpf_net_preferred(tmp_path):
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "executable": "x", "t0_ms": 0}]
+    records += [_tree_record(i * 100, cpu=10.0, rx=i * 100, ebpf=True) for i in range(5)]
+    src = tmp_path / "ebpf.jsonl"
+    _write_jsonl(src, records)
+
+    meta, rows = _load_records(str(src))
+    assert meta["_ebpf_seen"]
+    df, per_process = _to_frame(rows)
+    assert per_process
+    # rates come from the eBPF counters (1000 bytes per 0.1 s step)
+    assert df["rx_rate"].iloc[-1] == pytest.approx(10000)
+
+    generate_report(str(src), str(tmp_path / "r.html"))
+    assert "per-process (eBPF)" in (tmp_path / "r.html").read_text()
+
+
+def test_sparse_run_warns_and_still_renders(tmp_path):
+    # a process that exited early yields ~1 sample; the report must not be blank
+    records = [
+        {"kind": "metadata", "pid": 1, "cmd": ["x"], "executable": "x", "t0_ms": 0},
+        _tree_record(0, cpu=0.0, rx=0),
+    ]
+    src = tmp_path / "sparse.jsonl"
+    _write_jsonl(src, records)
+    generate_report(str(src), str(tmp_path / "r.html"))
+    html = (tmp_path / "r.html").read_text()
+    assert "too few samples" in html
+
+
+def test_detect_regimes_finds_phases(tmp_path):
+    # idle -> cpu-bound -> memory-growth; expect ~3 regimes with matching dominant labels
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "executable": "x", "t0_ms": 0}]
+    ts = 0
+    for _ in range(15):  # idle
+        records.append(_tree_record(ts, cpu=0.0, rx=0))
+        ts += 100
+    for _ in range(15):  # cpu-bound
+        records.append(_tree_record(ts, cpu=100.0, rx=0))
+        ts += 100
+    for i in range(15):  # memory growth
+        r = _tree_record(ts, cpu=1.0, rx=0)
+        r["aggregated"]["mem_rss_kb"] = r["parent"]["mem_rss_kb"] = 1024 * (i + 1) * 50
+        records.append(r)
+        ts += 100
+    src = tmp_path / "phases.jsonl"
+    _write_jsonl(src, records)
+
+    df, _ = _to_frame(_load_records(str(src))[1])
+    regimes = _detect_regimes(_slotted(df))
+    labels = [r["dominant"] for r in regimes]
+    assert len(regimes) >= 3
+    assert "cpu" in labels and "memory" in labels and "idle/low" in labels
+
+    generate_report(str(src), str(tmp_path / "r.html"))
+    assert "Detected regimes" in (tmp_path / "r.html").read_text()
+
+
+def test_detect_regimes_short_run_empty(tmp_path):
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "executable": "x", "t0_ms": 0}]
+    records += [_tree_record(i * 100, cpu=10.0, rx=0) for i in range(4)]
+    df, _ = _to_frame(_load_records_rows(tmp_path, records))
+    assert _detect_regimes(df) == []
+
+
+def _load_records_rows(tmp_path, records):
+    src = tmp_path / "short.jsonl"
+    _write_jsonl(src, records)
+    return _load_records(str(src))[1]
+
+
+def _tree_record_syscalls(ts_ms, cpu, by_category):
+    r = _tree_record(ts_ms, cpu=cpu, rx=0)
+    for m in (r["parent"], r["aggregated"]):
+        m["ebpf"] = {"syscalls": {"total": sum(by_category.values()), "by_category": by_category}}
+    return r
+
+
+def test_syscalls_per_regime(tmp_path):
+    # per-sample snapshots (not cumulative): phase 1 is file_io-heavy, phase 2 memory-heavy
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "executable": "x", "t0_ms": 0}]
+    ts = 0
+    for _ in range(15):  # phase 1: file_io heavy
+        records.append(_tree_record_syscalls(ts, cpu=90.0, by_category={"file_io": 100, "memory": 5}))
+        ts += 100
+    for _ in range(15):  # phase 2: memory heavy
+        records.append(_tree_record_syscalls(ts, cpu=5.0, by_category={"file_io": 2, "memory": 100}))
+        ts += 100
+    src = tmp_path / "sc.jsonl"
+    _write_jsonl(src, records)
+
+    _, rows = _load_records(str(src))
+    df, _ = _to_frame(rows)
+    regimes = _detect_regimes(_slotted(df))
+    breakdown = _syscalls_per_regime(_syscall_frame(rows), regimes)
+
+    by_regime = {}
+    for b in breakdown:
+        by_regime.setdefault(b["regime"], {})[b["category"]] = b["count"]
+    # first regime should be dominated by file_io, a later one by memory
+    assert by_regime["R1"]["file_io"] > by_regime["R1"].get("memory", 0)
+    last = by_regime[max(by_regime)]
+    assert last.get("memory", 0) > last.get("file_io", 0)
+
+    generate_report(str(src), str(tmp_path / "r.html"))
+    assert "Syscalls by category" in (tmp_path / "r.html").read_text()
+
+
+def test_syscall_chart_keeps_every_regime_on_axis():
+    # a regime with no syscalls must still appear (empty row), so the chart aligns
+    # with the regime table above it
+    import altair as alt
+
+    breakdown = [
+        {"regime": "R1", "category": "file_io", "count": 10.0},
+        {"regime": "R3", "category": "memory", "count": 5.0},
+    ]
+    spec = _syscall_chart(alt, breakdown, 700, ["R1", "R2", "R3"]).to_dict()
+    assert spec["encoding"]["y"]["scale"]["domain"] == ["R1", "R2", "R3"]  # R2 kept despite no data
+
+
+def test_psi_panel_shown_when_present(tmp_path):
+    def make(with_psi, psi_some=lambda i: 0.0):
+        records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "executable": "x", "t0_ms": 0}]
+        for i in range(12):
+            r = _tree_record(i * 100, cpu=10.0, rx=0)
+            if with_psi:
+                some = psi_some(i)
+                for m in (r["parent"], r["aggregated"]):
+                    m["psi_mem"] = {"some_avg10": some, "full_avg10": some / 3}
+            records.append(r)
+        return records
+
+    # PSI present (even flat zero) -> panel rendered
+    for label, some_fn in (("pressured", lambda i: 0.0 if i < 4 else 20.0), ("flat", lambda i: 0.0)):
+        src = tmp_path / f"{label}.jsonl"
+        _write_jsonl(src, make(True, some_fn))
+        _, rows = _load_records(str(src))
+        assert _psi_frame(rows) is not None
+        generate_report(str(src), str(tmp_path / f"{label}.html"))
+        assert "mem stall" in (tmp_path / f"{label}.html").read_text()
+
+    # no psi_mem at all -> no panel
+    none_src = tmp_path / "nopsi.jsonl"
+    _write_jsonl(none_src, make(False))
+    _, rows2 = _load_records(str(none_src))
+    assert _psi_frame(rows2) is None
+    generate_report(str(none_src), str(tmp_path / "nopsi.html"))
+    assert "mem stall" not in (tmp_path / "nopsi.html").read_text()
+
+
+def test_no_syscall_chart_without_ebpf(tmp_path):
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "executable": "x", "t0_ms": 0}]
+    records += [_tree_record(i * 100, cpu=10.0, rx=0) for i in range(10)]
+    src = tmp_path / "noebpf.jsonl"
+    _write_jsonl(src, records)
+    _, rows = _load_records(str(src))
+    assert _syscall_frame(rows) is None
+    generate_report(str(src), str(tmp_path / "r.html"))
+    assert "Syscalls by category" not in (tmp_path / "r.html").read_text()
+
+
+def test_output_format_toggle(tmp_path):
+    records = [{"kind": "metadata", "pid": 1, "cmd": ["x"], "executable": "x", "t0_ms": 0}]
+    records += [_tree_record(i * 100, cpu=50.0, rx=i * 100) for i in range(12)]
+    src = tmp_path / "m.jsonl"
+    _write_jsonl(src, records)
+
+    # explicit format
+    assert generate_report(str(src), str(tmp_path / "a.png"), fmt="png") == str(tmp_path / "a.png")
+    assert (tmp_path / "a.png").read_bytes()[:4] == b"\x89PNG"
+    # inferred from extension
+    generate_report(str(src), str(tmp_path / "b.svg"))
+    assert (tmp_path / "b.svg").read_text().lstrip().startswith("<svg")
+    # default is html (interactive/JS)
+    out = generate_report(str(src))
+    assert out.endswith(".html")
+    assert "vegaEmbed" in Path(out).read_text()
+
+
+def test_no_records_raises(tmp_path):
+    src = tmp_path / "empty.jsonl"
+    src.write_text('{"kind":"metadata","pid":1,"cmd":["x"],"executable":"x","t0_ms":0}\n')
+    with pytest.raises(ValueError, match="No metric records"):
+        generate_report(str(src))


### PR DESCRIPTION
Add `denet.report`, a Python report generator that renders CPU / memory / network timelines from a denet JSONL file with Altair/Vega-Lite. Shipped behind the `report` extra (altair, pandas, vl-convert-python) so the base package stays dependency-free; installs a `denet-report` console command.

- Timelines with per-point markers; a low-sample warning when a run has too few samples to draw a timeline (e.g. a process that exited early).
- Regime detection via binary segmentation over the z-scored signals, shown as shaded bands plus a per-regime summary table (span, mean CPU/RSS, dominant activity).
- eBPF-only panel: syscall category mix per regime (cumulative counts diffed across each regime span), rendered as a normalized stacked bar.
- Capability header (eBPF / PSI / perf) and per-process vs system-wide network.
- Output format toggle (-f/--format): html (interactive, default), png, svg (both static); inferred from the -o extension when omitted.
- Long runs are downsampled to <=512 time slots (mean gauges, max rates).

Also: set Cargo `default-run = "denet"` so `cargo run` needs no --bin, and mark `run <command>` as trailing_var_arg/allow_hyphen_values so child flags like `python -c` pass through instead of being parsed as denet options.