### PR TITLE
feat(ebpf): expose per-child network byte breakdown

### DIFF
--- a/docs/ebpf.md
+++ b/docs/ebpf.md
@@ -283,11 +283,24 @@ accounting to the monitored tree.
 **JSON output** (inside the aggregated metrics' `ebpf` object):
 
 ```json
-"network": { "rx_bytes": 10019992, "tx_bytes": 747 }
+"network": {
+  "rx_bytes": 10019992,
+  "tx_bytes": 747,
+  "per_pid": {
+    "4123": { "rx_bytes": 10019992, "tx_bytes": 512 },
+    "4130": { "rx_bytes": 0, "tx_bytes": 235 }
+  },
+  "retired": { "rx_bytes": 0, "tx_bytes": 0 }
+}
 ```
 
-If eBPF could not attach (missing capabilities), the object carries an
-`error` string instead of silently reporting zeros as real data.
+`rx_bytes`/`tx_bytes` are the tree totals (authoritative). `per_pid` breaks
+the bytes out by live PID (root + current children), omitted while empty.
+`retired` holds bytes from children that have already exited and are no longer
+attributable to a live PID, omitted while zero. The three reconcile exactly:
+`sum(per_pid) + retired == {rx,tx}_bytes`, so a report's breakdown always adds
+up to the totals. If eBPF could not attach (missing capabilities), the object
+carries an `error` string instead of silently reporting zeros as real data.
 
 **Required capabilities** are the same as the rest of the eBPF features
 (`cap_bpf,cap_perfmon,cap_dac_read_search` — see above). To verify the whole

--- a/src/ebpf/metrics.rs
+++ b/src/ebpf/metrics.rs
@@ -1,7 +1,7 @@
 //! eBPF-specific metrics structures
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// eBPF profiling metrics
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -39,6 +39,32 @@ pub struct NetworkMetrics {
     /// Error message if collection failed (e.g. kprobe attach denied)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+
+    /// Bytes broken out per live PID in the monitored tree (root + children).
+    /// The summed `rx_bytes`/`tx_bytes` above stay authoritative — they also
+    /// include already-exited PIDs (see `retired`). BTreeMap for deterministic
+    /// ordering in reports and tests.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub per_pid: BTreeMap<u32, PidNetBytes>,
+
+    /// Bytes from children that have exited, no longer attributable to any
+    /// live PID. `sum(per_pid) + retired == {rx,tx}_bytes` exactly, so a
+    /// report's breakdown adds up to the totals. Omitted while zero.
+    #[serde(skip_serializing_if = "PidNetBytes::is_zero", default)]
+    pub retired: PidNetBytes,
+}
+
+/// One PID's slice of the tree's network bytes. See [`NetworkMetrics::per_pid`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct PidNetBytes {
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+}
+
+impl PidNetBytes {
+    fn is_zero(&self) -> bool {
+        self.rx_bytes == 0 && self.tx_bytes == 0
+    }
 }
 
 impl EbpfMetrics {

--- a/src/ebpf/net_monitor.rs
+++ b/src/ebpf/net_monitor.rs
@@ -9,9 +9,9 @@
 //! errors (missing capabilities, locked-down kernel) surface as an error
 //! string in the returned metrics, and all methods become safe no-ops.
 
-use crate::ebpf::metrics::NetworkMetrics;
+use crate::ebpf::metrics::{NetworkMetrics, PidNetBytes};
 use crate::error::{DenetError, Result};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use aya::{maps::HashMap as BpfHashMap, programs::KProbe, Ebpf};
 
@@ -188,21 +188,33 @@ impl NetMonitor {
     pub fn get_metrics(&self) -> NetworkMetrics {
         let Some(ref map) = self.net_bytes else {
             return NetworkMetrics {
-                rx_bytes: 0,
-                tx_bytes: 0,
                 error: self.init_error.clone(),
+                ..Default::default()
             };
         };
 
         let (mut rx, mut tx) = (self.retired_rx, self.retired_tx);
-        for (_tgid, [r, t]) in map.iter().flatten() {
+        let mut per_pid = BTreeMap::new();
+        for (tgid, [r, t]) in map.iter().flatten() {
             rx += r;
             tx += t;
+            per_pid.insert(
+                tgid,
+                PidNetBytes {
+                    rx_bytes: r,
+                    tx_bytes: t,
+                },
+            );
         }
         NetworkMetrics {
             rx_bytes: rx,
             tx_bytes: tx,
             error: None,
+            per_pid,
+            retired: PidNetBytes {
+                rx_bytes: self.retired_rx,
+                tx_bytes: self.retired_tx,
+            },
         }
     }
 }

--- a/tests/ebpf_net_monitor_tests.rs
+++ b/tests/ebpf_net_monitor_tests.rs
@@ -58,11 +58,17 @@ fn test_net_monitor_graceful_degradation() {
         let _ = monitor.get_metrics();
     }
 
-    // JSON shape pin: rx/tx always present, error only when set.
+    // JSON shape pin: rx/tx always present, error only when set, per_pid
+    // omitted while empty (degraded mode never populates it).
     let json = serde_json::to_value(&metrics).unwrap();
     assert!(json.get("rx_bytes").is_some());
     assert!(json.get("tx_bytes").is_some());
     assert_eq!(json.get("error").is_some(), metrics.error.is_some());
+    assert_eq!(json.get("per_pid").is_some(), !metrics.per_pid.is_empty());
+    assert_eq!(json.get("retired").is_none(), metrics.retired == Default::default());
+    if metrics.error.is_some() {
+        assert!(metrics.per_pid.is_empty(), "degraded mode leaked per_pid");
+    }
 }
 
 /// Transfer `total` bytes over localhost TCP within this process, so both
@@ -127,6 +133,27 @@ fn test_net_monitor_tcp_localhost_privileged() {
         TOTAL,
         TOTAL + SLOP
     );
+
+    // Per-child breakdown: single-process tree, so our pid is the sole live
+    // entry and its bytes equal the aggregate (nothing retired here). This is
+    // the same map-iteration path that keys every child tgid separately.
+    let own = m.per_pid.get(&own_pid()).expect("own pid missing from per_pid");
+    assert_eq!(own.rx_bytes, m.rx_bytes, "per_pid rx != aggregate: {:?}", m);
+    assert_eq!(own.tx_bytes, m.tx_bytes, "per_pid tx != aggregate: {:?}", m);
+    assert!(
+        !m.per_pid.contains_key(&1),
+        "unmonitored pid leaked into per_pid: {:?}",
+        m
+    );
+
+    // Breakdown reconciles exactly: sum(per_pid) + retired == totals.
+    let (mut prx, mut ptx) = (m.retired.rx_bytes, m.retired.tx_bytes);
+    for b in m.per_pid.values() {
+        prx += b.rx_bytes;
+        ptx += b.tx_bytes;
+    }
+    assert_eq!(prx, m.rx_bytes, "per_pid+retired rx != total: {:?}", m);
+    assert_eq!(ptx, m.tx_bytes, "per_pid+retired tx != total: {:?}", m);
 }
 
 #[test]

--- a/tests/ebpf_net_monitor_tests.rs
+++ b/tests/ebpf_net_monitor_tests.rs
@@ -65,7 +65,10 @@ fn test_net_monitor_graceful_degradation() {
     assert!(json.get("tx_bytes").is_some());
     assert_eq!(json.get("error").is_some(), metrics.error.is_some());
     assert_eq!(json.get("per_pid").is_some(), !metrics.per_pid.is_empty());
-    assert_eq!(json.get("retired").is_none(), metrics.retired == Default::default());
+    assert_eq!(
+        json.get("retired").is_none(),
+        metrics.retired == Default::default()
+    );
     if metrics.error.is_some() {
         assert!(metrics.per_pid.is_empty(), "degraded mode leaked per_pid");
     }
@@ -137,7 +140,10 @@ fn test_net_monitor_tcp_localhost_privileged() {
     // Per-child breakdown: single-process tree, so our pid is the sole live
     // entry and its bytes equal the aggregate (nothing retired here). This is
     // the same map-iteration path that keys every child tgid separately.
-    let own = m.per_pid.get(&own_pid()).expect("own pid missing from per_pid");
+    let own = m
+        .per_pid
+        .get(&own_pid())
+        .expect("own pid missing from per_pid");
     assert_eq!(own.rx_bytes, m.rx_bytes, "per_pid rx != aggregate: {:?}", m);
     assert_eq!(own.tx_bytes, m.tx_bytes, "per_pid tx != aggregate: {:?}", m);
     assert!(


### PR DESCRIPTION
get_metrics now returns per-live-PID rx/tx (per_pid) plus a retired bucket for exited children, alongside the existing tree totals. Reconciles exactly: sum(per_pid) + retired == {rx,tx}_bytes, so a report breakdown adds up. Both new fields omit from JSON when empty/zero.