### PR TITLE
feat(energy): CPU (RAPL) + GPU (NVML) energy, per-process

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -36,6 +36,10 @@ ignore:
   # these paths can't be exercised from GitHub Actions. The pure logic that
   # consumes the syscall's output lives in src/perf/mod.rs and IS covered.
   - "src/perf/syscall.rs"
+  # RAPL powercap sysfs plumbing. Reading energy_uj needs root, so CI can't
+  # exercise these paths. The pure logic (cpu_share, counter_delta) lives in
+  # src/rapl/mod.rs and IS covered.
+  - "src/rapl/sysfs.rs"
 
 flags:
   python:

--- a/docs/cpu-measurement.md
+++ b/docs/cpu-measurement.md
@@ -114,3 +114,31 @@ CPU Usage: 376.2%  // A process using ~3.8 cores fully
 - For accurate CPU measurements over time, it's recommended to sample at regular intervals
 - First measurement establishes a baseline and returns no CPU usage value
 - Process tree measurements automatically track and cleanup child processes
+
+## CPU Energy (RAPL)
+
+When available, each sample carries a `rapl` field with CPU-package energy for
+the interval (see `docs/data-format.md`). Source: the cumulative microjoule
+counters at `/sys/class/powercap/intel-rapl:*/energy_uj`, diffed per sample
+(wrap-safe against `max_energy_range_uj`) and summed across package sockets.
+
+Two numbers:
+
+- **`package_joules`** — total socket energy: all cores, all processes, plus
+  static/uncore power. This is measured, not modeled.
+- **`process_joules`** — the slice attributed to the monitored process, as
+  `package_joules × (cpu_usage/100)/ncpus`.
+
+The attribution is a deliberate first-order model: it assumes package power
+tracks CPU-capacity share linearly. It ignores per-core DVFS, that an idle
+package still draws static power, and DRAM/uncore domains. Treat
+`process_joules` as an estimate and `package_joules` as ground truth. Upgrade
+paths (per-core `intel-rapl:N:0` energy, or cpu-time weighting against
+`/proc/stat` busy time) are noted in `src/rapl/mod.rs`.
+
+**Access:** `energy_uj` is root-owned `0400` on current kernels
+(CVE-2020-8694), so `rapl` resolves only under **root** or with
+**`CAP_DAC_READ_SEARCH`**. `scripts/setup_ebpf_caps.sh` grants that capability
+alongside the eBPF ones, so a caps-configured binary gets energy for free.
+Without it, the capability manifest reports `available: false` with a reason
+and the field is simply omitted.

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -68,6 +68,7 @@ Tells consumers which optional per-sample fields to expect. Each entry is `{avai
 |---|---|---|
 | `psi` | `psi_mem` | `/proc/pressure/memory` (system or per-process). Always Linux-only. |
 | `perf_hw` | `perf` | `perf_event_open` hardware counters. Requires `perf_event_paranoid <= 2` or `CAP_PERFMON`. The `events` array lists which counters opened — `cycles` and `instructions` are required, the rest degrade gracefully if the CPU doesn't expose them. |
+| `rapl` | `rapl` | Intel/AMD RAPL CPU-package energy via `/sys/class/powercap/intel-rapl:*/energy_uj`. `energy_uj` is root-owned `0400` on current kernels (CVE-2020-8694), so needs **root** or **`CAP_DAC_READ_SEARCH`** — `scripts/setup_ebpf_caps.sh` already grants it. The `zones` field counts package sockets being read. |
 
 ## Metrics Fields
 
@@ -97,7 +98,7 @@ Tells consumers which optional per-sample fields to expect. Each entry is `{avai
 | `thread_count` | number | Number of threads |
 | `uptime_secs` | number | Process uptime (seconds) |
 | `cpu_core` | number? | Last CPU core the process ran on, if known. |
-| `gpu` | object? | Per-process GPU metrics (only when the `gpu` feature is enabled and an NVIDIA GPU is present). |
+| `gpu` | object? | Per-process GPU metrics (only when the `gpu` feature is enabled and an NVIDIA GPU is present). May include `gpu_energy: {package_joules, process_joules}` — whole-board energy over the interval plus the slice attributed by GPU-util share (Volta+; see `docs/gpu.md`). |
 
 ### Child Process Metrics
 | Field | Type | Description |
@@ -114,6 +115,7 @@ Both Individual and Aggregated metrics may include these when the corresponding 
 |-------|------|-------------|
 | `psi_mem` | object? | `{some_avg10, full_avg10}` — fraction of the last 10s window in which at least one task / every task stalled on memory. |
 | `perf` | object? | `{cycles, instructions, cache_refs, cache_misses, stalled_backend}` — counter **deltas since the previous sample**. IPC = `instructions/cycles`. LLC miss rate = `cache_misses/cache_refs`. |
+| `rapl` | object? | `{package_joules, process_joules}` — CPU-package energy **over the sample interval** (joules). `package_joules` is the whole socket (all cores/processes); `process_joules` is the slice attributed to this process by CPU-capacity share `(cpu_usage/100)/ncpus`. A first-order model — see `docs/cpu-measurement.md`. |
 
 ### Aggregated Metrics
 Includes all fields from Individual Process Metrics plus:

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -108,6 +108,44 @@ GPU metrics are included in the JSON output:
 }
 ```
 
+## Energy (`gpu_energy`)
+
+When the GPU exposes NVML's cumulative energy counter (`total_energy_consumption`,
+**Volta and newer**, ~2017+), each `gpu` block also carries:
+
+```json
+"gpu_energy": { "package_joules": 12.4, "process_joules": 8.1 }
+```
+
+- **`package_joules`** — whole-board energy over the sample interval (all
+  processes + memory + static/idle draw), diffed from the NVML counter. Ground
+  truth, measured.
+- **`process_joules`** — the slice attributed to the monitored process(es) by
+  summed GPU-utilization share `(Σ proc_util) / 100`, clamped to the board total.
+
+**Caveat — whole-card vs per-process.** NVML has *no* per-process energy counter;
+the counter is always the entire board. So `process_joules` is an estimate, and a
+coarser one than the CPU/RAPL equivalent: nvidia-smi per-process "SM utilization"
+is the fraction of *time* a kernel was resident, not how many SMs or how much
+power it drew, and under MPS/concurrent contexts the per-process utilizations may
+not cleanly partition. Trust `package_joules`; treat `process_joules` as a guide.
+No counter (pre-Volta) → `gpu_energy` is omitted. No root or extra capability is
+needed (NVML runs as the invoking user).
+
+**Shared GPU.** `package_joules` is the whole board, so on a multi-tenant GPU it
+*includes* other users' and the display's draw — it is not scoped to you. But
+`process_joules` **is** scoped: it multiplies the board total by the summed GPU
+utilization of *your monitored pids only* (nvidia-smi reports SM utilization
+per-pid). So a neighbor's kernels are never charged to you — they raise the board
+total while your util share stays what your kernels actually used, i.e. you're
+attributed your fraction of a larger pie, not their energy. Accuracy still hinges
+on the per-pid util proxy, which is coarse under MPS/MIG.
+
+**Counter reliability.** The absolute values come straight from the driver's
+counter and are accurate on datacenter GPUs (A100/H100). On some laptop/Optimus
+dGPUs the counter is noisy and NVML polling itself perturbs the power state, so
+treat laptop readings as indicative, not billable.
+
 ## Notes
 
 - GPU monitoring requires NVIDIA GPUs and drivers

--- a/scripts/setup_ebpf_caps.sh
+++ b/scripts/setup_ebpf_caps.sh
@@ -5,6 +5,8 @@
 #   cap_bpf                - load BPF programs, create maps
 #   cap_perfmon            - perf_event_open for tracepoints
 #   cap_dac_read_search    - read /sys/kernel/tracing/events/*/id (root-owned 0400)
+#                            and RAPL /sys/class/powercap/intel-rapl:*/energy_uj
+#                            (also root-owned 0400) for CPU energy attribution
 #
 # Usage: sudo ./scripts/setup_ebpf_caps.sh [path/to/denet]
 # Defaults to ./target/release/denet.

--- a/src/bin/denet.rs
+++ b/src/bin/denet.rs
@@ -745,6 +745,7 @@ fn convert_aggregated_to_metrics(agg: &AggregatedMetrics) -> Metrics {
         cpu_core: None,
         gpu: agg.gpu.clone(),
         psi_mem: agg.psi_mem,
+        rapl: agg.rapl,
         #[cfg_attr(target_os = "linux", allow(clippy::clone_on_copy))]
         perf: agg.perf.clone(),
     }

--- a/src/core/process_monitor.rs
+++ b/src/core/process_monitor.rs
@@ -802,8 +802,11 @@ impl ProcessMonitor {
             // to this pid by its GPU-util share. `sample_metrics` deliberately
             // does not touch the counter (it runs multiple times per tick).
             if let Some(pkg_j) = self.gpu_monitor.board_energy_delta_joules() {
-                let utils: Vec<u32> =
-                    gm.process_data.iter().filter_map(|p| p.gpu_utilization).collect();
+                let utils: Vec<u32> = gm
+                    .process_data
+                    .iter()
+                    .filter_map(|p| p.gpu_utilization)
+                    .collect();
                 gm.gpu_energy = Some(crate::gpu::attribute_gpu_energy(pkg_j, &utils));
             }
             Some(gm)
@@ -1240,8 +1243,11 @@ impl ProcessMonitor {
                 // Reuse the board total already read for the parent this tick
                 // (do NOT read the counter again), re-attributed over all pids.
                 if let Some(pe) = parent.gpu.as_ref().and_then(|g| g.gpu_energy) {
-                    let utils: Vec<u32> =
-                        ag.process_data.iter().filter_map(|p| p.gpu_utilization).collect();
+                    let utils: Vec<u32> = ag
+                        .process_data
+                        .iter()
+                        .filter_map(|p| p.gpu_utilization)
+                        .collect();
                     ag.gpu_energy =
                         Some(crate::gpu::attribute_gpu_energy(pe.package_joules, &utils));
                 }

--- a/src/core/process_monitor.rs
+++ b/src/core/process_monitor.rs
@@ -140,6 +140,7 @@ fn init_mem_sources(pid: usize) -> (Option<crate::perf::PerfGroup>, Capabilities
         Capabilities {
             psi,
             perf_hw: Some(perf_cap),
+            rapl: Some(crate::rapl::detect()),
         },
     )
 }
@@ -147,7 +148,14 @@ fn init_mem_sources(pid: usize) -> (Option<crate::perf::PerfGroup>, Capabilities
 #[cfg(not(target_os = "linux"))]
 fn init_mem_sources(pid: usize) -> ((), Capabilities) {
     let psi = Some(crate::psi::detect(pid));
-    ((), Capabilities { psi, perf_hw: None })
+    (
+        (),
+        Capabilities {
+            psi,
+            perf_hw: None,
+            rapl: Some(crate::rapl::detect()),
+        },
+    )
 }
 
 /// Read metrics from a JSON file and generate a summary
@@ -272,6 +280,9 @@ pub struct ProcessMonitor {
     /// not supported. Detected once at startup.
     #[cfg(target_os = "linux")]
     perf_group: Option<crate::perf::PerfGroup>,
+    /// Cumulative CPU-package energy reader (RAPL); `None` if powercap sysfs is
+    /// absent or unreadable (usually not root). Holds prev counter per zone.
+    rapl_sampler: Option<crate::rapl::RaplSampler>,
     /// Whether per-process PSI is readable for `pid`. System-wide PSI is
     /// always tried as a fallback.
     psi_per_process: bool,
@@ -359,6 +370,7 @@ impl ProcessMonitor {
             gpu_monitor: crate::gpu::GpuMonitor::new(),
             #[cfg(target_os = "linux")]
             perf_group,
+            rapl_sampler: crate::rapl::RaplSampler::new(),
             psi_per_process,
             capabilities,
         })
@@ -455,6 +467,7 @@ impl ProcessMonitor {
             gpu_monitor: crate::gpu::GpuMonitor::new(),
             #[cfg(target_os = "linux")]
             perf_group,
+            rapl_sampler: crate::rapl::RaplSampler::new(),
             psi_per_process,
             capabilities,
         })
@@ -784,7 +797,16 @@ impl ProcessMonitor {
         // Sample GPU metrics if available
         #[cfg(feature = "gpu")]
         let gpu_metrics = if self.gpu_monitor.is_enabled() {
-            Some(self.gpu_monitor.sample_metrics(&[self.pid as u32]))
+            let mut gm = self.gpu_monitor.sample_metrics(&[self.pid as u32]);
+            // Board energy is read here — exactly once per tick — then attributed
+            // to this pid by its GPU-util share. `sample_metrics` deliberately
+            // does not touch the counter (it runs multiple times per tick).
+            if let Some(pkg_j) = self.gpu_monitor.board_energy_delta_joules() {
+                let utils: Vec<u32> =
+                    gm.process_data.iter().filter_map(|p| p.gpu_utilization).collect();
+                gm.gpu_energy = Some(crate::gpu::attribute_gpu_energy(pkg_j, &utils));
+            }
+            Some(gm)
         } else {
             None
         };
@@ -805,6 +827,12 @@ impl ProcessMonitor {
         #[cfg(not(target_os = "linux"))]
         let perf = None;
 
+        // CPU package energy (RAPL) + slice attributed by CPU share.
+        let rapl = self
+            .rapl_sampler
+            .as_mut()
+            .and_then(|s| s.sample_delta(cpu_usage));
+
         Some(Metrics {
             ts_ms,
             cpu_usage,
@@ -823,6 +851,7 @@ impl ProcessMonitor {
             cpu_core: Self::get_process_cpu_core(self.pid),
             gpu: gpu_metrics,
             psi_mem,
+            rapl,
             perf,
         })
     }
@@ -1076,6 +1105,7 @@ impl ProcessMonitor {
                     cpu_core: Self::get_process_cpu_core(*child_pid),
                     gpu: None,     // Child processes don't get individual GPU metrics
                     psi_mem: None, // PSI is per-tree, captured on the parent
+                    rapl: None,    // RAPL is per-tree, captured on the parent
                     perf: None,    // Per-child perf groups not opened (parent uses inherit=1)
                 };
 
@@ -1117,6 +1147,7 @@ impl ProcessMonitor {
                 ebpf: None, // Will be populated below if eBPF is enabled
                 gpu: None,  // Will be populated below if GPU is enabled
                 psi_mem: parent.psi_mem,
+                rapl: parent.rapl,
                 // On Linux `perf` is `Option<PerfCounters>` (Copy); on non-Linux
                 // it's `Option<serde_json::Value>` (not Copy). `.clone()` is the
                 // portable choice; clippy's lint fires only on the Linux build.
@@ -1205,7 +1236,16 @@ impl ProcessMonitor {
                 let all_pids: Vec<u32> = std::iter::once(self.pid as u32)
                     .chain(child_pids.iter().map(|&pid| pid as u32))
                     .collect();
-                agg.gpu = Some(self.gpu_monitor.sample_metrics(&all_pids));
+                let mut ag = self.gpu_monitor.sample_metrics(&all_pids);
+                // Reuse the board total already read for the parent this tick
+                // (do NOT read the counter again), re-attributed over all pids.
+                if let Some(pe) = parent.gpu.as_ref().and_then(|g| g.gpu_energy) {
+                    let utils: Vec<u32> =
+                        ag.process_data.iter().filter_map(|p| p.gpu_utilization).collect();
+                    ag.gpu_energy =
+                        Some(crate::gpu::attribute_gpu_energy(pe.package_joules, &utils));
+                }
+                agg.gpu = Some(ag);
             }
 
             #[cfg(not(feature = "gpu"))]

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -17,6 +17,15 @@
 //!
 //! The key insight is that NVML's device.utilization_rates() returns system-wide
 //! utilization, not per-process. For true per-process monitoring, we need nvidia-smi.
+//!
+//! # Energy
+//!
+//! NVML's `total_energy_consumption` is a cumulative millijoule counter for the
+//! **whole board** (all processes + static/idle draw) — there is no per-process
+//! energy counter. We diff it per sample for `package_joules` (ground truth) and
+//! attribute a `process_joules` slice by GPU-utilization share (an estimate, as
+//! coarse as the util proxy that feeds it). Volta+ only; older GPUs report no
+//! counter and `gpu_energy` is omitted.
 
 #[cfg(feature = "gpu")]
 use nvml_wrapper::enums::device::UsedGpuMemory;
@@ -62,6 +71,34 @@ pub struct SystemGpuMetrics {
     pub power_usage: Option<u32>,
 }
 
+/// GPU energy over one sample interval, in joules.
+///
+/// `package_joules` is whole-card energy (all processes + static draw), measured
+/// via NVML's cumulative counter. `process_joules` is the slice attributed to the
+/// monitored process(es) by GPU-utilization share — an estimate, not a
+/// per-process measurement (NVML exposes no such counter). See module docs.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq)]
+pub struct GpuEnergy {
+    /// Total board energy over the interval — all processes, all draw.
+    pub package_joules: f64,
+    /// Estimated slice for the monitored process(es) by GPU-util share.
+    pub process_joules: f64,
+}
+
+/// Split whole-board energy (joules over the interval) into total and the slice
+/// attributed to the monitored process(es) by summed GPU-util share (clamped).
+/// `package_joules` covers every process on the board; only `process_joules` is
+/// scoped to our pids — via `proc_utils`, which nvidia-smi reports per-pid, so
+/// other users' load lowers our util share rather than being charged to us.
+#[cfg(any(feature = "gpu", test))]
+pub(crate) fn attribute_gpu_energy(package_joules: f64, proc_utils: &[u32]) -> GpuEnergy {
+    let util_share = (proc_utils.iter().map(|&u| u as f64 / 100.0).sum::<f64>()).clamp(0.0, 1.0);
+    GpuEnergy {
+        package_joules,
+        process_joules: package_joules * util_share + 0.0, // `+ 0.0` normalizes -0.0
+    }
+}
+
 /// Complete GPU monitoring data for a single process
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct GpuMetrics {
@@ -73,6 +110,10 @@ pub struct GpuMetrics {
     pub has_process_data: bool,
     /// Method used for process data collection
     pub collection_method: String,
+    /// Board energy this interval + attributed slice. Present only when NVML's
+    /// `total_energy_consumption` counter is available (Volta+, ~2017 on).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_energy: Option<GpuEnergy>,
 }
 
 /// GPU monitoring summary
@@ -117,6 +158,12 @@ pub struct GpuMonitor {
     device_count: u32,
     enabled: bool,
     nvidia_smi_available: bool,
+    /// Previous cumulative energy per device (millijoules) for delta computation.
+    /// `RefCell` because `sample_metrics` takes `&self`; single-threaded sampling
+    /// so no contention. ponytail: RefCell over threading the state through every
+    /// caller — swap to `&mut self` only if sampling ever goes concurrent.
+    #[cfg(feature = "gpu")]
+    prev_energy_mj: std::cell::RefCell<std::collections::HashMap<u32, u64>>,
 }
 
 impl Default for GpuMonitor {
@@ -144,6 +191,7 @@ impl GpuMonitor {
                         device_count,
                         enabled: true,
                         nvidia_smi_available,
+                        prev_energy_mj: Default::default(),
                     }
                 }
                 Err(e) => {
@@ -154,6 +202,7 @@ impl GpuMonitor {
                             device_count: Self::get_device_count_nvidia_smi(),
                             enabled: true,
                             nvidia_smi_available: true,
+                            prev_energy_mj: Default::default(),
                         }
                     } else {
                         log::info!("GPU monitoring disabled: {}", e);
@@ -162,6 +211,7 @@ impl GpuMonitor {
                             device_count: 0,
                             enabled: false,
                             nvidia_smi_available: false,
+                            prev_energy_mj: Default::default(),
                         }
                     }
                 }
@@ -234,6 +284,40 @@ impl GpuMonitor {
         #[cfg(not(feature = "gpu"))]
         {
             0
+        }
+    }
+
+    /// Whole-board energy since the previous call, in joules, summed across
+    /// devices. Reads NVML's cumulative `total_energy_consumption` counter and
+    /// advances the per-device baseline — so call it **exactly once per emitted
+    /// sample** (`sample_metrics` may run several times per tick and must not
+    /// touch the counter). Returns `None` if no device exposes the counter
+    /// (pre-Volta) or the GPU is disabled.
+    pub fn board_energy_delta_joules(&self) -> Option<f64> {
+        #[cfg(feature = "gpu")]
+        {
+            let nvml = self.nvml.as_ref()?;
+            let mut delta_mj: u64 = 0;
+            let mut seen = false;
+            let mut prev = self.prev_energy_mj.borrow_mut();
+            for device_index in 0..self.device_count {
+                if let Ok(device) = nvml.device_by_index(device_index) {
+                    if let Ok(cur_mj) = device.total_energy_consumption() {
+                        seen = true;
+                        // Cumulative since driver reload; monotonic, so a decrease
+                        // only means the driver reset — treat as 0.
+                        if let Some(&last) = prev.get(&device_index) {
+                            delta_mj += cur_mj.saturating_sub(last);
+                        }
+                        prev.insert(device_index, cur_mj);
+                    }
+                }
+            }
+            seen.then(|| delta_mj as f64 / 1000.0)
+        }
+        #[cfg(not(feature = "gpu"))]
+        {
+            None
         }
     }
 
@@ -328,6 +412,10 @@ impl GpuMonitor {
                 process_data,
                 has_process_data,
                 collection_method,
+                // Energy is read once per tick via `board_energy_delta_joules`
+                // (this method is called several times per tick); the caller
+                // attaches it. See ProcessMonitor sampling.
+                gpu_energy: None,
             }
         }
 
@@ -520,6 +608,23 @@ mod tests {
         // Should not panic regardless of GPU availability
         let _device_count = monitor.device_count();
         let _enabled = monitor.is_enabled();
+    }
+
+    #[test]
+    fn test_gpu_energy_attribution() {
+        // 5 J board energy; one proc at 40% util → 2 J attributed.
+        let e = attribute_gpu_energy(5.0, &[40]);
+        assert!((e.package_joules - 5.0).abs() < 1e-9);
+        assert!((e.process_joules - 2.0).abs() < 1e-9);
+
+        // Multiple procs sum; over-100% clamps to the whole board.
+        let e = attribute_gpu_energy(5.0, &[80, 70]);
+        assert!((e.process_joules - 5.0).abs() < 1e-9);
+
+        // No per-process util → total known, nothing attributed.
+        let e = attribute_gpu_energy(5.0, &[]);
+        assert_eq!(e.process_joules, 0.0);
+        assert!((e.package_joules - 5.0).abs() < 1e-9);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod cpu_sampler;
 #[cfg(target_os = "linux")]
 pub mod perf;
 pub mod psi;
+pub mod rapl;
 
 // eBPF profiling (optional feature)
 #[cfg(feature = "ebpf")]

--- a/src/monitor/metrics.rs
+++ b/src/monitor/metrics.rs
@@ -19,6 +19,8 @@ pub struct Capabilities {
     #[cfg(not(target_os = "linux"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub perf_hw: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rapl: Option<crate::rapl::RaplCapability>,
 }
 
 /// Metadata about a monitored process
@@ -102,6 +104,11 @@ pub struct Metrics {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub psi_mem: Option<crate::psi::PsiMem>,
 
+    /// CPU package energy this interval (RAPL), plus the slice attributed to
+    /// this process. Linux-only, requires readable powercap sysfs (usually root).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rapl: Option<crate::rapl::RaplEnergy>,
+
     /// Hardware perf-counter deltas since the previous sample. Linux-only,
     /// requires `perf_event_paranoid <= 2` or `CAP_PERFMON`. Consumer can
     /// derive IPC = `instructions/cycles` and LLC miss rate from a single
@@ -141,6 +148,7 @@ impl Metrics {
             cpu_core: None,
             gpu: None,
             psi_mem: None,
+            rapl: None,
             perf: None,
         }
     }
@@ -217,6 +225,11 @@ pub struct AggregatedMetrics {
     /// inventing an aggregation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub psi_mem: Option<crate::psi::PsiMem>,
+
+    /// CPU package energy this interval (RAPL), per-tree like PSI. Taken from
+    /// the first sample that reported it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rapl: Option<crate::rapl::RaplEnergy>,
 
     /// Sum of per-process perf-counter deltas across the tree. Sums are
     /// meaningful for IPC/miss-rate ratios because we sum numerator and
@@ -295,6 +308,7 @@ impl AggregatedMetrics {
             ebpf: None, // eBPF metrics are added separately
             gpu: None,  // GPU metrics are added separately
             psi_mem: metrics.iter().find_map(|m| m.psi_mem),
+            rapl: metrics.iter().find_map(|m| m.rapl),
             #[cfg(target_os = "linux")]
             perf: aggregate_perf(metrics),
             #[cfg(not(target_os = "linux"))]
@@ -350,6 +364,7 @@ impl Default for AggregatedMetrics {
             ebpf: None,
             gpu: None,
             psi_mem: None,
+            rapl: None,
             perf: None,
         }
     }

--- a/src/rapl/mod.rs
+++ b/src/rapl/mod.rs
@@ -1,0 +1,241 @@
+//! CPU energy via Intel/AMD RAPL exposed through the powercap sysfs interface.
+//!
+//! `/sys/class/powercap/intel-rapl:<N>/energy_uj` is a **cumulative** microjoule
+//! counter per CPU package (socket). It wraps at `max_energy_range_uj`. We read
+//! every top-level package zone, diff against the previous sample (wrap-safe),
+//! and sum to get the package energy spent this interval — the *total*.
+//!
+//! We then attribute a *slice* of that total to the monitored process by its
+//! share of machine CPU capacity: `(cpu_usage% / 100) / ncpus`. This is a
+//! first-order linear model — it ignores per-core DVFS, uncore/DRAM domains,
+//! and that an idle package still burns static power.
+//!
+//! ponytail: linear cpu-share attribution. Upgrade path if it proves too coarse:
+//! weight by per-core `intel-rapl:N:0` (pp0/core) energy, or by cpu-time against
+//! `/proc/stat` busy time instead of capacity. Left as a knob, not built yet.
+//!
+//! Reading `energy_uj` is root-only on most kernels (CVE-2020-8694 mitigation),
+//! so absence is the common case and degrades to `None`, never an error.
+
+use serde::{Deserialize, Serialize};
+
+/// Energy spent during one sample interval, in joules.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq)]
+pub struct RaplEnergy {
+    /// Total package (socket) energy over the interval — all cores, all processes.
+    pub package_joules: f64,
+    /// Estimated slice attributed to the monitored process (see module docs).
+    pub process_joules: f64,
+}
+
+/// Process share of total machine CPU capacity, clamped to [0, 1].
+/// `cpu_usage` is percent where 100 = one full core (may exceed 100).
+fn cpu_share(cpu_usage: f32, ncpus: usize) -> f64 {
+    if ncpus == 0 {
+        return 0.0;
+    }
+    ((cpu_usage as f64 / 100.0) / ncpus as f64).clamp(0.0, 1.0)
+}
+
+/// Wrap-safe delta of a cumulative counter that resets at `max`.
+fn counter_delta(prev: u64, cur: u64, max: u64) -> u64 {
+    if cur >= prev {
+        cur - prev
+    } else if max > 0 {
+        // Counter wrapped past its range.
+        max - prev + cur
+    } else {
+        0
+    }
+}
+
+#[cfg(target_os = "linux")]
+const POWERCAP_DIR: &str = "/sys/class/powercap";
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct Zone {
+    energy_path: std::path::PathBuf,
+    max_uj: u64,
+    last_uj: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn read_uj(path: &std::path::Path) -> Option<u64> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+/// A package zone is `intel-rapl:<N>` — top level, no second `:` component.
+#[cfg(target_os = "linux")]
+fn is_package_zone(name: &str) -> bool {
+    match name.strip_prefix("intel-rapl:") {
+        Some(rest) => !rest.is_empty() && !rest.contains(':'),
+        None => false,
+    }
+}
+
+/// Stateful RAPL reader. Holds the previous counter per package zone.
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+pub struct RaplSampler {
+    zones: Vec<Zone>,
+    ncpus: usize,
+}
+
+#[cfg(target_os = "linux")]
+impl RaplSampler {
+    /// Discover readable package zones and take the initial reading. Returns
+    /// `None` if the interface is absent or no zone's `energy_uj` is readable
+    /// (typically: not root).
+    pub fn new() -> Option<Self> {
+        let mut zones = Vec::new();
+        for entry in std::fs::read_dir(POWERCAP_DIR).ok()?.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !is_package_zone(&name) {
+                continue;
+            }
+            let dir = entry.path();
+            let energy_path = dir.join("energy_uj");
+            let Some(last_uj) = read_uj(&energy_path) else {
+                continue; // unreadable (permissions) — skip this zone
+            };
+            let max_uj = read_uj(&dir.join("max_energy_range_uj")).unwrap_or(0);
+            zones.push(Zone {
+                energy_path,
+                max_uj,
+                last_uj,
+            });
+        }
+        if zones.is_empty() {
+            return None;
+        }
+        let ncpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        Some(Self { zones, ncpus })
+    }
+
+    /// Energy since the previous call. First call after `new()` returns a small
+    /// nonzero delta (time between construction and first sample).
+    pub fn sample_delta(&mut self, cpu_usage: f32) -> Option<RaplEnergy> {
+        let mut total_uj: u64 = 0;
+        for z in &mut self.zones {
+            let cur = read_uj(&z.energy_path)?;
+            total_uj += counter_delta(z.last_uj, cur, z.max_uj);
+            z.last_uj = cur;
+        }
+        let package_joules = total_uj as f64 / 1_000_000.0;
+        Some(RaplEnergy {
+            package_joules,
+            process_joules: package_joules * cpu_share(cpu_usage, self.ncpus),
+        })
+    }
+}
+
+/// Capability manifest entry for the JSONL header.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RaplCapability {
+    pub available: bool,
+    /// Number of package zones being read.
+    pub zones: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[cfg(target_os = "linux")]
+pub fn detect() -> RaplCapability {
+    match RaplSampler::new() {
+        Some(s) => RaplCapability {
+            available: true,
+            zones: s.zones.len(),
+            reason: None,
+        },
+        None => RaplCapability {
+            available: false,
+            zones: 0,
+            reason: Some(
+                "no readable intel-rapl package zone (interface absent or needs root)".to_string(),
+            ),
+        },
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[derive(Debug)]
+pub struct RaplSampler;
+
+#[cfg(not(target_os = "linux"))]
+impl RaplSampler {
+    pub fn new() -> Option<Self> {
+        None
+    }
+    pub fn sample_delta(&mut self, _cpu_usage: f32) -> Option<RaplEnergy> {
+        None
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn detect() -> RaplCapability {
+    RaplCapability {
+        available: false,
+        zones: 0,
+        reason: Some("RAPL is Linux-only".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_delta_normal() {
+        assert_eq!(counter_delta(100, 300, 1000), 200);
+    }
+
+    #[test]
+    fn wrap_delta_wraps() {
+        // prev near max, cur small → wrapped once.
+        assert_eq!(counter_delta(900, 100, 1000), 200);
+    }
+
+    #[test]
+    fn wrap_delta_no_max_clamps_to_zero() {
+        // Decreasing counter with no known range: can't tell, report 0.
+        assert_eq!(counter_delta(500, 100, 0), 0);
+    }
+
+    #[test]
+    fn share_single_core_of_four() {
+        // 100% (one full core) on a 4-core box = 1/4 of capacity.
+        assert!((cpu_share(100.0, 4) - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn share_clamps_and_guards() {
+        assert_eq!(cpu_share(100.0, 0), 0.0); // no divide-by-zero
+        assert_eq!(cpu_share(1000.0, 4), 1.0); // over-100% multi-thread clamps
+        assert_eq!(cpu_share(0.0, 8), 0.0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn zone_name_matching() {
+        assert!(is_package_zone("intel-rapl:0"));
+        assert!(is_package_zone("intel-rapl:1"));
+        assert!(!is_package_zone("intel-rapl:0:0")); // sub-zone (core/dram)
+        assert!(!is_package_zone("intel-rapl-mmio:0")); // mmio mirror
+        assert!(!is_package_zone("intel-rapl:")); // malformed
+        assert!(!is_package_zone("other"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn detect_does_not_panic() {
+        // On a box without root/RAPL this is unavailable with a reason.
+        let cap = detect();
+        if !cap.available {
+            assert!(cap.reason.is_some());
+        }
+    }
+}

--- a/src/rapl/mod.rs
+++ b/src/rapl/mod.rs
@@ -16,8 +16,15 @@
 //!
 //! Reading `energy_uj` is root-only on most kernels (CVE-2020-8694 mitigation),
 //! so absence is the common case and degrades to `None`, never an error.
+//!
+//! The powercap sysfs plumbing lives in `sysfs.rs`, which is excluded from
+//! coverage — CI runners can't read `energy_uj` without root. The pure logic
+//! it consumes (`cpu_share`, `counter_delta`) lives here and IS covered.
 
 use serde::{Deserialize, Serialize};
+
+mod sysfs;
+pub use sysfs::{detect, RaplSampler};
 
 /// Energy spent during one sample interval, in joules.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq)]
@@ -26,111 +33,6 @@ pub struct RaplEnergy {
     pub package_joules: f64,
     /// Estimated slice attributed to the monitored process (see module docs).
     pub process_joules: f64,
-}
-
-/// Process share of total machine CPU capacity, clamped to [0, 1].
-/// `cpu_usage` is percent where 100 = one full core (may exceed 100).
-fn cpu_share(cpu_usage: f32, ncpus: usize) -> f64 {
-    if ncpus == 0 {
-        return 0.0;
-    }
-    ((cpu_usage as f64 / 100.0) / ncpus as f64).clamp(0.0, 1.0)
-}
-
-/// Wrap-safe delta of a cumulative counter that resets at `max`.
-fn counter_delta(prev: u64, cur: u64, max: u64) -> u64 {
-    if cur >= prev {
-        cur - prev
-    } else if max > 0 {
-        // Counter wrapped past its range.
-        max - prev + cur
-    } else {
-        0
-    }
-}
-
-#[cfg(target_os = "linux")]
-const POWERCAP_DIR: &str = "/sys/class/powercap";
-
-#[cfg(target_os = "linux")]
-#[derive(Debug)]
-struct Zone {
-    energy_path: std::path::PathBuf,
-    max_uj: u64,
-    last_uj: u64,
-}
-
-#[cfg(target_os = "linux")]
-fn read_uj(path: &std::path::Path) -> Option<u64> {
-    std::fs::read_to_string(path).ok()?.trim().parse().ok()
-}
-
-/// A package zone is `intel-rapl:<N>` — top level, no second `:` component.
-#[cfg(target_os = "linux")]
-fn is_package_zone(name: &str) -> bool {
-    match name.strip_prefix("intel-rapl:") {
-        Some(rest) => !rest.is_empty() && !rest.contains(':'),
-        None => false,
-    }
-}
-
-/// Stateful RAPL reader. Holds the previous counter per package zone.
-#[cfg(target_os = "linux")]
-#[derive(Debug)]
-pub struct RaplSampler {
-    zones: Vec<Zone>,
-    ncpus: usize,
-}
-
-#[cfg(target_os = "linux")]
-impl RaplSampler {
-    /// Discover readable package zones and take the initial reading. Returns
-    /// `None` if the interface is absent or no zone's `energy_uj` is readable
-    /// (typically: not root).
-    pub fn new() -> Option<Self> {
-        let mut zones = Vec::new();
-        for entry in std::fs::read_dir(POWERCAP_DIR).ok()?.flatten() {
-            let name = entry.file_name();
-            let name = name.to_string_lossy();
-            if !is_package_zone(&name) {
-                continue;
-            }
-            let dir = entry.path();
-            let energy_path = dir.join("energy_uj");
-            let Some(last_uj) = read_uj(&energy_path) else {
-                continue; // unreadable (permissions) — skip this zone
-            };
-            let max_uj = read_uj(&dir.join("max_energy_range_uj")).unwrap_or(0);
-            zones.push(Zone {
-                energy_path,
-                max_uj,
-                last_uj,
-            });
-        }
-        if zones.is_empty() {
-            return None;
-        }
-        let ncpus = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1);
-        Some(Self { zones, ncpus })
-    }
-
-    /// Energy since the previous call. First call after `new()` returns a small
-    /// nonzero delta (time between construction and first sample).
-    pub fn sample_delta(&mut self, cpu_usage: f32) -> Option<RaplEnergy> {
-        let mut total_uj: u64 = 0;
-        for z in &mut self.zones {
-            let cur = read_uj(&z.energy_path)?;
-            total_uj += counter_delta(z.last_uj, cur, z.max_uj);
-            z.last_uj = cur;
-        }
-        let package_joules = total_uj as f64 / 1_000_000.0;
-        Some(RaplEnergy {
-            package_joules,
-            process_joules: package_joules * cpu_share(cpu_usage, self.ncpus),
-        })
-    }
 }
 
 /// Capability manifest entry for the JSONL header.
@@ -143,44 +45,28 @@ pub struct RaplCapability {
     pub reason: Option<String>,
 }
 
-#[cfg(target_os = "linux")]
-pub fn detect() -> RaplCapability {
-    match RaplSampler::new() {
-        Some(s) => RaplCapability {
-            available: true,
-            zones: s.zones.len(),
-            reason: None,
-        },
-        None => RaplCapability {
-            available: false,
-            zones: 0,
-            reason: Some(
-                "no readable intel-rapl package zone (interface absent or needs root)".to_string(),
-            ),
-        },
+/// Process share of total machine CPU capacity, clamped to [0, 1].
+/// `cpu_usage` is percent where 100 = one full core (may exceed 100).
+/// Only used by the Linux-gated sampler; `test` keeps it for cross-platform tests.
+#[cfg(any(target_os = "linux", test))]
+pub(crate) fn cpu_share(cpu_usage: f32, ncpus: usize) -> f64 {
+    if ncpus == 0 {
+        return 0.0;
     }
+    ((cpu_usage as f64 / 100.0) / ncpus as f64).clamp(0.0, 1.0)
 }
 
-#[cfg(not(target_os = "linux"))]
-#[derive(Debug)]
-pub struct RaplSampler;
-
-#[cfg(not(target_os = "linux"))]
-impl RaplSampler {
-    pub fn new() -> Option<Self> {
-        None
-    }
-    pub fn sample_delta(&mut self, _cpu_usage: f32) -> Option<RaplEnergy> {
-        None
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn detect() -> RaplCapability {
-    RaplCapability {
-        available: false,
-        zones: 0,
-        reason: Some("RAPL is Linux-only".to_string()),
+/// Wrap-safe delta of a cumulative counter that resets at `max`.
+/// Only used by the Linux-gated sampler; `test` keeps it for cross-platform tests.
+#[cfg(any(target_os = "linux", test))]
+pub(crate) fn counter_delta(prev: u64, cur: u64, max: u64) -> u64 {
+    if cur >= prev {
+        cur - prev
+    } else if max > 0 {
+        // Counter wrapped past its range.
+        max - prev + cur
+    } else {
+        0
     }
 }
 
@@ -216,26 +102,5 @@ mod tests {
         assert_eq!(cpu_share(100.0, 0), 0.0); // no divide-by-zero
         assert_eq!(cpu_share(1000.0, 4), 1.0); // over-100% multi-thread clamps
         assert_eq!(cpu_share(0.0, 8), 0.0);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn zone_name_matching() {
-        assert!(is_package_zone("intel-rapl:0"));
-        assert!(is_package_zone("intel-rapl:1"));
-        assert!(!is_package_zone("intel-rapl:0:0")); // sub-zone (core/dram)
-        assert!(!is_package_zone("intel-rapl-mmio:0")); // mmio mirror
-        assert!(!is_package_zone("intel-rapl:")); // malformed
-        assert!(!is_package_zone("other"));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn detect_does_not_panic() {
-        // On a box without root/RAPL this is unavailable with a reason.
-        let cap = detect();
-        if !cap.available {
-            assert!(cap.reason.is_some());
-        }
     }
 }

--- a/src/rapl/sysfs.rs
+++ b/src/rapl/sysfs.rs
@@ -1,0 +1,157 @@
+//! Powercap sysfs plumbing for RAPL. Excluded from coverage (see codecov.yml):
+//! reading `energy_uj` needs root, so CI can't exercise these paths. The pure
+//! logic these methods call lives in the parent module and is covered there.
+
+#[cfg(target_os = "linux")]
+use super::{counter_delta, cpu_share};
+use super::{RaplCapability, RaplEnergy};
+
+#[cfg(target_os = "linux")]
+const POWERCAP_DIR: &str = "/sys/class/powercap";
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct Zone {
+    energy_path: std::path::PathBuf,
+    max_uj: u64,
+    last_uj: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn read_uj(path: &std::path::Path) -> Option<u64> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+/// A package zone is `intel-rapl:<N>` — top level, no second `:` component.
+#[cfg(target_os = "linux")]
+fn is_package_zone(name: &str) -> bool {
+    match name.strip_prefix("intel-rapl:") {
+        Some(rest) => !rest.is_empty() && !rest.contains(':'),
+        None => false,
+    }
+}
+
+/// Stateful RAPL reader. Holds the previous counter per package zone.
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+pub struct RaplSampler {
+    zones: Vec<Zone>,
+    ncpus: usize,
+}
+
+#[cfg(target_os = "linux")]
+impl RaplSampler {
+    /// Discover readable package zones and take the initial reading. Returns
+    /// `None` if the interface is absent or no zone's `energy_uj` is readable
+    /// (typically: not root).
+    pub fn new() -> Option<Self> {
+        let mut zones = Vec::new();
+        for entry in std::fs::read_dir(POWERCAP_DIR).ok()?.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !is_package_zone(&name) {
+                continue;
+            }
+            let dir = entry.path();
+            let energy_path = dir.join("energy_uj");
+            let Some(last_uj) = read_uj(&energy_path) else {
+                continue; // unreadable (permissions) — skip this zone
+            };
+            let max_uj = read_uj(&dir.join("max_energy_range_uj")).unwrap_or(0);
+            zones.push(Zone {
+                energy_path,
+                max_uj,
+                last_uj,
+            });
+        }
+        if zones.is_empty() {
+            return None;
+        }
+        let ncpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        Some(Self { zones, ncpus })
+    }
+
+    /// Energy since the previous call. First call after `new()` returns a small
+    /// nonzero delta (time between construction and first sample).
+    pub fn sample_delta(&mut self, cpu_usage: f32) -> Option<RaplEnergy> {
+        let mut total_uj: u64 = 0;
+        for z in &mut self.zones {
+            let cur = read_uj(&z.energy_path)?;
+            total_uj += counter_delta(z.last_uj, cur, z.max_uj);
+            z.last_uj = cur;
+        }
+        let package_joules = total_uj as f64 / 1_000_000.0;
+        Some(RaplEnergy {
+            package_joules,
+            process_joules: package_joules * cpu_share(cpu_usage, self.ncpus),
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn detect() -> RaplCapability {
+    match RaplSampler::new() {
+        Some(s) => RaplCapability {
+            available: true,
+            zones: s.zones.len(),
+            reason: None,
+        },
+        None => RaplCapability {
+            available: false,
+            zones: 0,
+            reason: Some(
+                "no readable intel-rapl package zone (interface absent or needs root)".to_string(),
+            ),
+        },
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[derive(Debug)]
+pub struct RaplSampler;
+
+#[cfg(not(target_os = "linux"))]
+impl RaplSampler {
+    pub fn new() -> Option<Self> {
+        None
+    }
+    pub fn sample_delta(&mut self, _cpu_usage: f32) -> Option<RaplEnergy> {
+        None
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn detect() -> RaplCapability {
+    RaplCapability {
+        available: false,
+        zones: 0,
+        reason: Some("RAPL is Linux-only".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn zone_name_matching() {
+        assert!(is_package_zone("intel-rapl:0"));
+        assert!(is_package_zone("intel-rapl:1"));
+        assert!(!is_package_zone("intel-rapl:0:0")); // sub-zone (core/dram)
+        assert!(!is_package_zone("intel-rapl-mmio:0")); // mmio mirror
+        assert!(!is_package_zone("intel-rapl:")); // malformed
+        assert!(!is_package_zone("other"));
+    }
+
+    #[test]
+    fn detect_does_not_panic() {
+        // On a box without root/RAPL this is unavailable with a reason.
+        let cap = detect();
+        if !cap.available {
+            assert!(cap.reason.is_some());
+        }
+    }
+}


### PR DESCRIPTION
Add a first parse of CPU and GPU energy, each reporting a measured total plus a slice attributed to the monitored process.

CPU: new `src/rapl/mod.rs` reads the cumulative µJ counters at /sys/class/powercap/intel-rapl:*/energy_uj, wrap-safe-diffs them per sample, and sums packages. `RaplEnergy { package_joules, process_joules }` on each Metrics; process slice = total × (cpu_usage/100)/ncpus. Stateful RaplSampler wired like perf_group; RaplCapability in the JSONL header manifest. energy_uj is root-owned 0400 (CVE-2020-8694), so it needs root or CAP_DAC_READ_SEARCH — which scripts/setup_ebpf_caps.sh already grants (comment updated).

GPU: `GpuEnergy { package_joules, process_joules }` on GpuMetrics, sourced from NVML's cumulative total_energy_consumption counter (Volta+). The counter read moves to a single board_energy_delta_joules() called exactly once per tick — sample_metrics runs several times per tick and must not advance the counter. package_joules is whole-board; process_joules is attributed by the summed per-pid GPU-util share, so other tenants' load is never charged to us.

Attribution is a first-order linear model in both cases (ponytail comments note the upgrade paths). Verified on real hardware: summed per-tick package_joules matches the raw NVML counter delta modulo the first-sample baseline.

Docs: cpu-measurement.md (RAPL section), gpu.md (energy + shared-GPU/reliability caveats), data-format.md (manifest + field rows).